### PR TITLE
Merges conv1d and conv2d to Convolution

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,36 +3,95 @@
 # If you wish to continue using _config.yml, make edits to that file and
 # re-generate this one.
 ###############################################################################
-author = 'Steven Abreu, Felix Bauer, Jason Eshraghian, Matthias Jobst, Gregor Lenz, Jens Egholm Pedersen, Sadique Sheik'
-bibtex_bibfiles = ['references.bib']
-comments_config = {'hypothesis': False, 'utterances': False}
-copyright = '2022'
-exclude_patterns = ['**.ipynb_checkpoints', '.DS_Store', 'Thumbs.db', '_build']
-extensions = ['sphinx_togglebutton', 'sphinx_copybutton', 'myst_nb', 'jupyter_book', 'sphinx_thebe', 'sphinx_comments', 'sphinx_external_toc', 'sphinx.ext.intersphinx', 'sphinx_design', 'sphinx_book_theme', 'sphinx_inline_tabs', 'sphinx_proof', 'sphinx_examples', 'hoverxref.extension', 'sphinxcontrib.bibtex', 'sphinx_jupyterbook_latex']
+author = "Steven Abreu, Felix Bauer, Jason Eshraghian, Matthias Jobst, Gregor Lenz, Jens Egholm Pedersen, Sadique Sheik"
+bibtex_bibfiles = ["references.bib"]
+comments_config = {"hypothesis": False, "utterances": False}
+copyright = "2022"
+exclude_patterns = ["**.ipynb_checkpoints", ".DS_Store", "Thumbs.db", "_build"]
+extensions = [
+    "sphinx_togglebutton",
+    "sphinx_copybutton",
+    "myst_nb",
+    "jupyter_book",
+    "sphinx_thebe",
+    "sphinx_comments",
+    "sphinx_external_toc",
+    "sphinx.ext.intersphinx",
+    "sphinx_design",
+    "sphinx_book_theme",
+    "sphinx_inline_tabs",
+    "sphinx_proof",
+    "sphinx_examples",
+    "hoverxref.extension",
+    "sphinxcontrib.bibtex",
+    "sphinx_jupyterbook_latex",
+]
 external_toc_exclude_missing = False
-external_toc_path = '_toc.yml'
-hoverxref_intersphinx = ['sphinxproof']
-html_baseurl = ''
-html_favicon = ''
-html_logo = 'logo.png'
-html_sourcelink_suffix = ''
-html_theme = 'sphinx_book_theme'
-html_theme_options = {'search_bar_text': 'Search this book...', 'launch_buttons': {'notebook_interface': 'classic', 'binderhub_url': '', 'jupyterhub_url': '', 'thebe': False, 'colab_url': ''}, 'path_to_docs': 'docs', 'repository_url': 'https://github.com/neuromorphs/nir', 'repository_branch': 'docs', 'extra_footer': '', 'home_page_in_toc': True, 'announcement': '', 'analytics': {'google_analytics_id': ''}, 'use_repository_button': True, 'use_edit_page_button': False, 'use_issues_button': True}
-html_title = 'NIR Docs'
-intersphinx_mapping = {'ebp': ['https://executablebooks.org/en/latest/', None], 'myst-parser': ['https://myst-parser.readthedocs.io/en/latest/', None], 'myst-nb': ['https://myst-nb.readthedocs.io/en/latest/', None], 'sphinx': ['https://www.sphinx-doc.org/en/master', None], 'nbformat': ['https://nbformat.readthedocs.io/en/latest', None], 'sd': ['https://sphinx-design.readthedocs.io/en/latest', None], 'sphinxproof': ['https://sphinx-proof.readthedocs.io/en/latest/', None]}
-latex_engine = 'pdflatex'
-mathjax3_config = {'tex': {'macros': {'N': '\\mathbb{N}', 'floor': ['\\lfloor#1\\rfloor', 1], 'bmat': ['\\left[\\begin{array}'], 'emat': ['\\end{array}\\right]']}}}
-myst_enable_extensions = ['colon_fence', 'dollarmath', 'linkify', 'substitution', 'tasklist']
-myst_url_schemes = ['mailto', 'http', 'https']
+external_toc_path = "_toc.yml"
+hoverxref_intersphinx = ["sphinxproof"]
+html_baseurl = ""
+html_favicon = ""
+html_logo = "logo.png"
+html_sourcelink_suffix = ""
+html_theme = "sphinx_book_theme"
+html_theme_options = {
+    "search_bar_text": "Search this book...",
+    "launch_buttons": {
+        "notebook_interface": "classic",
+        "binderhub_url": "",
+        "jupyterhub_url": "",
+        "thebe": False,
+        "colab_url": "",
+    },
+    "path_to_docs": "docs",
+    "repository_url": "https://github.com/neuromorphs/nir",
+    "repository_branch": "docs",
+    "extra_footer": "",
+    "home_page_in_toc": True,
+    "announcement": "",
+    "analytics": {"google_analytics_id": ""},
+    "use_repository_button": True,
+    "use_edit_page_button": False,
+    "use_issues_button": True,
+}
+html_title = "NIR Docs"
+intersphinx_mapping = {
+    "ebp": ["https://executablebooks.org/en/latest/", None],
+    "myst-parser": ["https://myst-parser.readthedocs.io/en/latest/", None],
+    "myst-nb": ["https://myst-nb.readthedocs.io/en/latest/", None],
+    "sphinx": ["https://www.sphinx-doc.org/en/master", None],
+    "nbformat": ["https://nbformat.readthedocs.io/en/latest", None],
+    "sd": ["https://sphinx-design.readthedocs.io/en/latest", None],
+    "sphinxproof": ["https://sphinx-proof.readthedocs.io/en/latest/", None],
+}
+latex_engine = "pdflatex"
+mathjax3_config = {
+    "tex": {
+        "macros": {
+            "N": "\\mathbb{N}",
+            "floor": ["\\lfloor#1\\rfloor", 1],
+            "bmat": ["\\left[\\begin{array}"],
+            "emat": ["\\end{array}\\right]"],
+        }
+    }
+}
+myst_enable_extensions = [
+    "colon_fence",
+    "dollarmath",
+    "linkify",
+    "substitution",
+    "tasklist",
+]
+myst_url_schemes = ["mailto", "http", "https"]
 nb_execution_allow_errors = False
-nb_execution_cache_path = ''
+nb_execution_cache_path = ""
 nb_execution_excludepatterns = []
 nb_execution_in_temp = False
-nb_execution_mode = 'force'
+nb_execution_mode = "force"
 nb_execution_timeout = 30
-nb_output_stderr = 'show'
+nb_output_stderr = "show"
 numfig = True
-pygments_style = 'sphinx'
-suppress_warnings = ['myst.domains']
+pygments_style = "sphinx"
+suppress_warnings = ["myst.domains"]
 use_jupyterbook_latex = True
 use_multitoc_numbering = True

--- a/nir/__init__.py
+++ b/nir/__init__.py
@@ -1,3 +1,3 @@
-from .ir import * # noqa: F403
-from .read import read # noqa: F401
-from .write import write # noqa: F401
+from .ir import *  # noqa: F403
+from .read import read  # noqa: F401
+from .write import write  # noqa: F401

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -20,20 +20,24 @@ class NIRNode:
 
     pass
 
+
 @dataclass
 class Input(NIRNode):
     """Input Node.
 
     This is a virtual node, which allows feeding in data into the graph.
     """
-    shape: np.ndarray # Shape of input data
+
+    shape: np.ndarray  # Shape of input data
+
 
 @dataclass
 class Output(NIRNode):
     """Output Node.
-    
+
     Defines an output of the graph.
     """
+
     pass
 
 
@@ -84,7 +88,6 @@ class LIF(NIRNode):
 
 @dataclass
 class Linear(NIRNode):
-
     weights: np.ndarray  # Weights M * N
     bias: np.ndarray  # Bias M
 
@@ -92,10 +95,10 @@ class Linear(NIRNode):
 @dataclass
 class Convolution(NIRNode):
     """Convolutional layer in arbitrary dimension.
-    
-    Weights denote the kernels of the convolution according to 
-    $C_out \times C_in \times W_0 \times ... \times W_m $ where $W$ is the weight for the $m$th dimension
-    in the convolution (from 1 upwards).
+
+    Weights denote the kernels of the convolution according to
+    $C_out \times C_in \times W_0 \times ... \times W_m $ where $W$ is the weight
+    for the $m$th dimension in the convolution (from 1 upwards).
     A PyTorch `Conv1d` model would be represented by $C_out \times C_in \times W_0$.
     """
 
@@ -118,4 +121,4 @@ class Threshold(NIRNode):
 class Delay(NIRNode):
     """Simple delay node."""
 
-    delay: np.ndarray # Delay
+    delay: np.ndarray  # Delay

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -90,27 +90,21 @@ class Linear(NIRNode):
 
 
 @dataclass
-class Conv1d(NIRNode):
-    """Convolutional layer in 1d"""
+class Convolution(NIRNode):
+    """Convolutional layer in arbitrary dimension.
+    
+    Weights denote the kernels of the convolution according to 
+    $C_out \times C_in \times W_0 \times ... \times W_m $ where $W$ is the weight for the $m$th dimension
+    in the convolution (from 1 upwards).
+    A PyTorch `Conv1d` model would be represented by $C_out \times C_in \times W_0$.
+    """
 
     weights: np.ndarray  # Weights C_out * C_in * X
+    bias: np.ndarray  # Bias C_out
     stride: int  # Stride
     padding: int  # Padding
     dilation: int  # Dilation
     groups: int  # Groups
-    bias: np.ndarray  # Bias C_out
-
-
-@dataclass
-class Conv2d(NIRNode):
-    """Convolutional layer in 2d"""
-
-    weights: np.ndarray  # Weights C_out * C_in * X * Y
-    stride: int  # Stride
-    padding: int  # Padding
-    dilation: int  # Dilation
-    groups: int  # Groups
-    bias: np.ndarray  # Bias C_out
 
 
 @dataclass

--- a/nir/read.py
+++ b/nir/read.py
@@ -17,10 +17,7 @@ def read(filename: typing.Union[str, pathlib.Path]) -> nir.NIR:
                     )
                 )
             elif node["type"][()] == b"Output":
-                nodes.append(
-                    nir.Output(
-                    )
-                )
+                nodes.append(nir.Output())
             elif node["type"][()] == b"LI":
                 nodes.append(
                     nir.LI(

--- a/nir/read.py
+++ b/nir/read.py
@@ -45,20 +45,9 @@ def read(filename: typing.Union[str, pathlib.Path]) -> nir.NIR:
                         bias=node["bias"][()],
                     )
                 )
-            elif node["type"][()] == b"Conv1d":
+            elif node["type"][()] == b"Convolution":
                 nodes.append(
-                    nir.Conv1d(
-                        weights=node["weights"][()],
-                        stride=node["stride"][()],
-                        padding=node["padding"][()],
-                        dilation=node["dilation"][()],
-                        groups=node["groups"][()],
-                        bias=node["bias"][()],
-                    )
-                )
-            elif node["type"][()] == b"Conv2d":
-                nodes.append(
-                    nir.Conv2d(
+                    nir.Convolution(
                         weights=node["weights"][()],
                         stride=node["stride"][()],
                         padding=node["padding"][()],

--- a/nir/test/test_ir.py
+++ b/nir/test/test_ir.py
@@ -7,36 +7,63 @@ def test_simple():
     assert ir.nodes[0].bias == 4
     assert ir.edges == [(0, 0)]
 
+
 def test_simple_with_input_output():
     ir = nir.NIR(
         nodes=[
-            nir.Input(shape=[3,]),
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
             nir.Linear(weights=[1, 2, 3], bias=4),
-            nir.Output()],
-        edges=[(0, 1), (1,2)])
-    assert ir.nodes[0].shape == [3,]
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
+    )
+    assert ir.nodes[0].shape == [
+        3,
+    ]
     assert ir.nodes[1].weights == [1, 2, 3]
     assert ir.nodes[1].bias == 4
     assert ir.edges == [(0, 1), (1, 2)]
 
+
 def test_delay():
     ir = nir.NIR(
         nodes=[
-            nir.Input(shape=[3,]),
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
             nir.Delay(delay=[1, 2, 3]),
-            nir.Output()],
-        edges=[(0, 1), (1,2)])
-    assert ir.nodes[0].shape == [3,]
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
+    )
+    assert ir.nodes[0].shape == [
+        3,
+    ]
     assert ir.nodes[1].delay == [1, 2, 3]
     assert ir.edges == [(0, 1), (1, 2)]
+
 
 def test_threshold():
     ir = nir.NIR(
         nodes=[
-            nir.Input(shape=[3,]),
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
             nir.Threshold(threshold=[2.0, 2.5, 2.8]),
-            nir.Output()],
-        edges=[(0, 1), (1,2)])
-    assert ir.nodes[0].shape == [3,]
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
+    )
+    assert ir.nodes[0].shape == [
+        3,
+    ]
     assert ir.nodes[1].threshold == [2.0, 2.5, 2.8]
     assert ir.edges == [(0, 1), (1, 2)]

--- a/nir/test/test_readwrite.py
+++ b/nir/test/test_readwrite.py
@@ -29,9 +29,13 @@ def test_leaky_integrator():
     )
     factory_test_graph(ir)
 
+
 def test_convolution():
     ir = nir.NIR(
-        nodes=[nir.Linear(weights=[1], bias=[0]), nir.Convolution(np.ones((3, 3, 3)), np.ones((3,)), 1, 1, 1, 1)],
+        nodes=[
+            nir.Linear(weights=[1], bias=[0]),
+            nir.Convolution(np.ones((3, 3, 3)), np.ones((3,)), 1, 1, 1, 1),
+        ],
         edges=[(0, 1)],
     )
     factory_test_graph(ir)
@@ -39,34 +43,58 @@ def test_convolution():
 
 def test_leaky_integrator_and_fire():
     ir = nir.NIR(
-        nodes=[nir.Linear(weights=[1], bias=0), nir.LIF(tau=1, r=2, v_leak=3, v_threshold=4)],
+        nodes=[
+            nir.Linear(weights=[1], bias=0),
+            nir.LIF(tau=1, r=2, v_leak=3, v_threshold=4),
+        ],
         edges=[(0, 0)],
     )
     factory_test_graph(ir)
 
+
 def test_simple_with_read_write():
     ir = nir.NIR(
-        nodes=[nir.Input(shape=[3,]),
-               nir.Linear(weights=[1, 2, 3], bias=4),
-               nir.Output()],
-        edges=[(0, 1), (1,2)]
+        nodes=[
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
+            nir.Linear(weights=[1, 2, 3], bias=4),
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
     )
     factory_test_graph(ir)
+
 
 def test_delay():
     ir = nir.NIR(
-        nodes=[nir.Input(shape=[3,]),
-               nir.Delay(delay=[1, 2, 3]),
-               nir.Output()],
-        edges=[(0, 1), (1,2)]
+        nodes=[
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
+            nir.Delay(delay=[1, 2, 3]),
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
     )
     factory_test_graph(ir)
 
+
 def test_threshold():
     ir = nir.NIR(
-        nodes=[nir.Input(shape=[3,]),
-               nir.Threshold(threshold=[2.0, 2.5, 2.8]),
-               nir.Output()],
-        edges=[(0, 1), (1,2)]
+        nodes=[
+            nir.Input(
+                shape=[
+                    3,
+                ]
+            ),
+            nir.Threshold(threshold=[2.0, 2.5, 2.8]),
+            nir.Output(),
+        ],
+        edges=[(0, 1), (1, 2)],
     )
     factory_test_graph(ir)

--- a/nir/test/test_readwrite.py
+++ b/nir/test/test_readwrite.py
@@ -24,8 +24,15 @@ def test_simple():
 
 def test_leaky_integrator():
     ir = nir.NIR(
-        nodes=[nir.Linear(weights=[1], bias=0), nir.LI(tau=1, r=2, v_leak=3)],
+        nodes=[nir.Linear(weights=[1], bias=[0]), nir.LI(tau=1, r=2, v_leak=3)],
         edges=[(0, 0)],
+    )
+    factory_test_graph(ir)
+
+def test_convolution():
+    ir = nir.NIR(
+        nodes=[nir.Linear(weights=[1], bias=[0]), nir.Convolution(np.ones((3, 3, 3)), np.ones((3,)), 1, 1, 1, 1)],
+        edges=[(0, 1)],
     )
     factory_test_graph(ir)
 

--- a/nir/write.py
+++ b/nir/write.py
@@ -39,19 +39,9 @@ def write(filename: typing.Union[str, pathlib.Path], graph: nir.NIR) -> None:
                 "weights": node.weights,
                 "bias": node.bias,
             }
-        elif isinstance(node, nir.Conv1d):
+        elif isinstance(node, nir.Convolution):
             return {
-                "type": "Conv1d",
-                "weights": node.weights,
-                "stride": node.stride,
-                "padding": node.padding,
-                "dilation": node.dilation,
-                "groups": node.groups,
-                "bias": node.bias,
-            }
-        elif isinstance(node, nir.Conv2d):
-            return {
-                "type": "Conv2d",
+                "type": "Convolution",
                 "weights": node.weights,
                 "stride": node.stride,
                 "padding": node.padding,

--- a/nir/write.py
+++ b/nir/write.py
@@ -50,15 +50,9 @@ def write(filename: typing.Union[str, pathlib.Path], graph: nir.NIR) -> None:
                 "bias": node.bias,
             }
         elif isinstance(node, nir.Delay):
-            return {
-                "type": "Delay",
-                "delay": node.delay
-            }
+            return {"type": "Delay", "delay": node.delay}
         elif isinstance(node, nir.Threshold):
-            return {
-                "type": "Threshold",
-                "threshold": node.threshold
-            }
+            return {"type": "Threshold", "threshold": node.threshold}
         else:
             raise ValueError(f"Unknown node type: {node}")
 


### PR DESCRIPTION
We presently represent dimensionality of the nodes implicitly via their weights. Except in the case of Convolution. 
This PR attempts to merge this, such that PyTorch `Conv1d` is represented as
```python
nir.Convolution(
  weights=np.zeros((1, 2, 3)),
  bias=np.zeros((3,)),
  ...
)
```

`Conv2d` would simply be expanding the weights and biases one dimension