### PR TITLE
fixed dev_requirements.txt

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 pre-commit
 ruff
 black
-hdf5
+h5py
 numpy
 pytest
 sphinx


### PR DESCRIPTION
There was a typo in the `dev_requirements.txt`, requiring "hdf5" instead of "h5py".