### PR TITLE
meaningful node naming when using from_list()

### DIFF
--- a/nir/ir.py
+++ b/nir/ir.py
@@ -1,4 +1,5 @@
 import typing
+from collections import Counter
 from dataclasses import dataclass
 
 import numpy as np
@@ -31,32 +32,22 @@ class NIRGraph(NIRNode):
         """Create a sequential graph from a list of nodes by labelling them after
         indices."""
 
-        def unique_node_name(node, name_dict):
-            print(node)
+        def unique_node_name(node, counts):
             basename = node.__class__.__name__.lower()
-            print(basename)
-            idx = None
-            if basename in name_dict.keys():
-                idx = name_dict[basename]
-            if idx is not None:
-                name = basename + "_" + str(idx)
-                idx += 1
-            else:
-                name = basename
-                idx = 1
-            name_dict[basename] = idx
+            id = counts[basename]
+            name = f"{basename}{f'_{id}' if id>0 else ''}"
+            counts[basename] += 1
             return name
 
-        name_dict = {}
-        names = []
+        counts = Counter()
         node_dict = {}
         edges = []
 
         for node in nodes:
-            name = unique_node_name(node, name_dict)
+            name = unique_node_name(node, counts)
             node_dict[name] = node
-            names.append(name)
 
+        names = list(node_dict)
         for i in range(len(nodes) - 1):
             edges.append((names[i], names[i + 1]))
 

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import typing
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -30,9 +30,39 @@ class NIRGraph(NIRNode):
     def from_list(*nodes: NIRNode) -> "NIRGraph":
         """Create a sequential graph from a list of nodes by labelling them after
         indices."""
+
+        def unique_node_name(node, name_dict):
+            print(node)
+            basename = node.__class__.__name__.lower()
+            print(basename)
+            idx = None
+            if basename in name_dict.keys():
+                idx = name_dict[basename]
+            if idx is not None:
+                name = basename + "_" + str(idx)
+                idx += 1
+            else:
+                name = basename
+                idx = 1
+            name_dict[basename] = idx
+            return name
+
+        name_dict = {}
+        names = []
+        node_dict = {}
+        edges = []
+
+        for node in nodes:
+            name = unique_node_name(node, name_dict)
+            node_dict[name] = node
+            names.append(name)
+
+        for i in range(len(nodes) - 1):
+            edges.append((names[i], names[i + 1]))
+
         return NIRGraph(
-            nodes={str(i): n for i, n in enumerate(nodes)},
-            edges=[(str(i), str(i + 1)) for i in range(len(nodes) - 1)],
+            nodes=node_dict,
+            edges=edges,
         )
 
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -117,3 +117,69 @@ def test_flatten():
     )
     assert np.allclose(ir.nodes["in"].shape, [4, 5, 2])
     assert np.allclose(ir.nodes["out"].shape, [20, 2])
+
+
+def test_from_list_naming():
+    ir = nir.NIRGraph.from_list(
+        nir.Input(shape=np.array([2])),
+        nir.Linear(weight=np.array([[3, 1], [-1, 2], [1, 2]])),
+        nir.Linear(weight=np.array([[3, 1], [-1, 4], [1, 2]]).T),
+        nir.Affine(
+            weight=np.array([[2, 1], [-1, 2], [1, 2]]), bias=np.array([1, 3, 2])
+        ),
+        nir.Affine(
+            weight=np.array([[2, 1], [-1, 4], [1, 2]]).T, bias=np.array([-2, 2])
+        ),
+        nir.Linear(weight=np.array([[3, 1], [-1, 1], [1, 2]])),
+        nir.Linear(weight=np.array([[3, 1], [-1, 3], [1, 2]]).T),
+        nir.Affine(
+            weight=np.array([[2, 1], [-1, 1], [1, 2]]), bias=np.array([1, 5, 2])
+        ),
+        nir.Affine(
+            weight=np.array([[2, 1], [-1, 3], [1, 2]]).T, bias=np.array([-2, 3])
+        ),
+        nir.Output(shape=np.array([2])),
+    )
+    assert "input" in ir.nodes.keys()
+    assert "linear" in ir.nodes.keys()
+    assert "linear_1" in ir.nodes.keys()
+    assert "linear_2" in ir.nodes.keys()
+    assert "linear_3" in ir.nodes.keys()
+    assert "affine" in ir.nodes.keys()
+    assert "affine_1" in ir.nodes.keys()
+    assert "affine_2" in ir.nodes.keys()
+    assert "affine_3" in ir.nodes.keys()
+    assert "output" in ir.nodes.keys()
+    assert np.allclose(ir.nodes["input"].shape, [2])
+    assert np.allclose(ir.nodes["linear"].weight, np.array([[3, 1], [-1, 2], [1, 2]]))
+    assert np.allclose(
+        ir.nodes["linear_1"].weight, np.array([[3, 1], [-1, 4], [1, 2]]).T
+    )
+    assert np.allclose(ir.nodes["affine"].weight, np.array([[2, 1], [-1, 2], [1, 2]]))
+    assert np.allclose(ir.nodes["affine"].bias, np.array([1, 3, 2]))
+    assert np.allclose(
+        ir.nodes["affine_1"].weight, np.array([[2, 1], [-1, 4], [1, 2]]).T
+    )
+    assert np.allclose(ir.nodes["affine_1"].bias, np.array([-2, 2]))
+    assert np.allclose(ir.nodes["linear_2"].weight, np.array([[3, 1], [-1, 1], [1, 2]]))
+    assert np.allclose(
+        ir.nodes["linear_3"].weight, np.array([[3, 1], [-1, 3], [1, 2]]).T
+    )
+    assert np.allclose(ir.nodes["affine_2"].weight, np.array([[2, 1], [-1, 1], [1, 2]]))
+    assert np.allclose(ir.nodes["affine_2"].bias, np.array([1, 5, 2]))
+    assert np.allclose(
+        ir.nodes["affine_3"].weight, np.array([[2, 1], [-1, 3], [1, 2]]).T
+    )
+    assert np.allclose(ir.nodes["affine_3"].bias, np.array([-2, 3]))
+    assert np.allclose(ir.nodes["output"].shape, [2])
+    assert ir.edges == [
+        ("input", "linear"),
+        ("linear", "linear_1"),
+        ("linear_1", "affine"),
+        ("affine", "affine_1"),
+        ("affine_1", "linear_2"),
+        ("linear_2", "linear_3"),
+        ("linear_3", "affine_2"),
+        ("affine_2", "affine_3"),
+        ("affine_3", "output"),
+    ]


### PR DESCRIPTION
Implementation for Issue #20 
This should not break any end user code because it is just a modification on the naming of the nodes generated by NIRGraph.from_list().
Naming follows Tensorflow convention:
First occurence of Node type will get classname in lower case, from the second occurence a `_<i>` is appended, where `<i>` is the count of previous occurences.
Example:
input -> dense -> dense_1 -> affine -> dense_2 -> affine ->output