### PR TITLE
add input/output shape annotations for all nodes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,19 @@ Each computational unit is a node in a static graph.
 Given 3 nodes $A$ which is a LIF node, $B$ which is a Linear node and $C$ which is another LIF node, we can define edges in the graph such as:
 
 ```mermaid
-graph RL;
+graph LR;
 A --> B;
 B --> C;
+```
+
+Or more complicated graphs, such as
+
+```mermaid
+graph LR;
+A --> A;
+A --> B;
+B --> C;
+A --> C;
 ```
 
 ## Format

--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@ The goal of NIR is to provide a common format that different neuromorphic framew
 ## Computational primitives
 > Read more about in our [documentation about NIR primitives](https://nnir.readthedocs.io/en/latest/primitives.html)
 
-On top of popular primitives such as convolutional or fully connected/linear computations, we define additional compuational primitives that are specific to neuromorphic computing and hardware implementations thereof. Computational units that are not specifically neuromorphic take inspiration from the Pytorch ecosystem in terms of naming and parameters (such as Conv2d that uses groups/strides).
+On top of popular primitives such as convolutional or fully connected/linear computations, we define additional compuational primitives that are specific to neuromorphic computing and hardware implementations thereof. 
+Computational units that are not specifically neuromorphic take inspiration from the Pytorch ecosystem in terms of naming and parameters (such as Conv2d that uses groups/strides).
 
 ## Connectivity 
-Each computational unit is a node in a static graph. Given 3 nodes $A$ which is a LIF node, $B$ which is a Linear node and $C$ which is another LIF node, we can define edges in the graph such as:
+Each computational unit is a node in a static graph.
+Given 3 nodes $A$ which is a LIF node, $B$ which is a Linear node and $C$ which is another LIF node, we can define edges in the graph such as:
 
-$$
-A \rightarrow B \\
-B \rightarrow C
-$$
+```mermaid
+graph RL;
+A --> B;
+B --> C;
+```
 
 ## Format
 The intermediate represenation can be stored as hdf5 file, which benefits from compression. 

--- a/example/sinabs/export_from_sinabs.py
+++ b/example/sinabs/export_from_sinabs.py
@@ -3,7 +3,6 @@ import torch
 import torch.nn as nn
 from sinabs import from_nir, to_nir
 
-
 batch_size = 4
 
 # Create Sinabs model

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -1,6 +1,6 @@
 import typing
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 import numpy as np
 
@@ -238,7 +238,7 @@ class Flatten(NIRNode):
 
     # Shape of input tensor (overrrides input_shape from
     # NIRNode to allow for non-keyword (positional) initialization)
-    input_shape: Shape = field(kw_only=False)
+    input_shape: Shape
     start_dim: int = 1  # First dimension to flatten
     end_dim: int = -1  # Last dimension to flatten
 
@@ -322,7 +322,7 @@ class Input(NIRNode):
 
     # Shape of incoming data (overrrides input_shape from
     # NIRNode to allow for non-keyword (positional) initialization)
-    input_shape: Shape = field(kw_only=False)
+    input_shape: Shape
 
     def __post_init__(self):
         if isinstance(self.input_shape, np.ndarray):
@@ -428,7 +428,7 @@ class Output(NIRNode):
 
     # Shape of incoming data (overrrides input_shape from
     # NIRNode to allow for non-keyword (positional) initialization)
-    output_shape: Shape = field(kw_only=False)
+    output_shape: Shape
 
     def __post_init__(self):
         if isinstance(self.output_shape, np.ndarray):

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -20,8 +20,9 @@ class NIRNode:
     instantiated.
     """
 
-    input_shape: Shape = field(init=False, kw_only=True)
-    output_shape: Shape = field(init=False, kw_only=True)
+    # Note: Adding input/output shapes as follows is ideal, but requires Python 3.10
+    # input_shape: Shape = field(init=False, kw_only=True)
+    # output_shape: Shape = field(init=False, kw_only=True)
 
 
 @dataclass
@@ -111,9 +112,7 @@ class Affine(NIRNode):
             )
         }
         self.output_shape = {
-            "output": np.array(
-                self.weight.shape[:-2] + (self.weight.shape[-2],)
-            )
+            "output": np.array(self.weight.shape[:-2] + (self.weight.shape[-2],))
         }
 
 
@@ -207,7 +206,6 @@ class CubaLIF(NIRNode):
         ), "All parameters must have the same shape"
         # If w_in is a scalar, make it an array of same shape as v_threshold
         self.w_in = np.ones_like(self.v_threshold) * self.w_in
-        # set input and output shape, if not set by user
         self.input_shape = {"input": np.array(self.v_threshold.shape)}
         self.output_shape = {"output": np.array(self.v_threshold.shape)}
 
@@ -245,16 +243,18 @@ class Flatten(NIRNode):
     end_dim: int = -1  # Last dimension to flatten
 
     def __post_init__(self):
-        assert list(self.input_shape.keys()) == ["input"], "Flatten must have one input: `input`"
+        assert list(self.input_shape.keys()) == [
+            "input"
+        ], "Flatten must have one input: `input`"
         if isinstance(self.input_shape, np.ndarray):
             self.input_shape = {"input": self.input_shape}
-        concat = self.input_shape["input"][self.start_dim:self.end_dim].prod()
+        concat = self.input_shape["input"][self.start_dim : self.end_dim].prod()
         self.output_shape = {
             "output": np.array(
                 [
-                    *self.input_shape["input"][:self.start_dim],
+                    *self.input_shape["input"][: self.start_dim],
                     concat,
-                    *self.input_shape["input"][self.end_dim:],
+                    *self.input_shape["input"][self.end_dim :],
                 ]
             )
         }

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -106,10 +106,14 @@ class Affine(NIRNode):
     def __post_init__(self):
         assert len(self.weight.shape) >= 2, "Weight must be at least 2D"
         self.input_shape = {
-            "input": self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-1:]).T)
+            "input": np.array(
+                self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-1:]).T)
+            )
         }
         self.output_shape = {
-            "output": self.weight.shape[:-2] + (self.weight.shape[-2],)
+            "output": np.array(
+                self.weight.shape[:-2] + (self.weight.shape[-2],)
+            )
         }
 
 
@@ -231,6 +235,7 @@ class Flatten(NIRNode):
     """Flatten node.
 
     This node flattens its input tensor.
+    input_shape must be a dict with one key: "input".
     """
 
     # Shape of input tensor (overrrides input_shape from
@@ -240,17 +245,16 @@ class Flatten(NIRNode):
     end_dim: int = -1  # Last dimension to flatten
 
     def __post_init__(self):
-        assert len(self.input_shape.keys()) == 1, "Flatten only supports one input"
-        input_key = list(self.input_shape.keys())[0]
+        assert list(self.input_shape.keys()) == ["input"], "Flatten must have one input: `input`"
         if isinstance(self.input_shape, np.ndarray):
-            self.input_shape = {input_key: self.input_shape}
-        concat = self.input_shape[input_key][self.start_dim:self.end_dim].prod()
+            self.input_shape = {"input": self.input_shape}
+        concat = self.input_shape["input"][self.start_dim:self.end_dim].prod()
         self.output_shape = {
             "output": np.array(
                 [
-                    *self.input_shape[input_key][:self.start_dim],
+                    *self.input_shape["input"][:self.start_dim],
                     concat,
-                    *self.input_shape[input_key][self.end_dim:],
+                    *self.input_shape["input"][self.end_dim:],
                 ]
             )
         }

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -40,6 +40,9 @@ class NIRGraph(NIRNode):
         """Create a sequential graph from a list of nodes by labelling them after
         indices."""
 
+        if len(nodes) > 0 and (isinstance(nodes[0], list) or isinstance(nodes[0], tuple)):
+            nodes = [*nodes[0]]
+
         def unique_node_name(node, counts):
             basename = node.__class__.__name__.lower()
             id = counts[basename]
@@ -344,7 +347,7 @@ class Linear(NIRNode):
         self.input_shape = np.array(
             self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-2:]).T)
         )
-        self.output_shape = self.weight.shape[:-2] + (self.weight.shape[-2], )
+        self.output_shape = self.weight.shape[:-2] + (self.weight.shape[-2],)
 
 
 @dataclass

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -106,7 +106,7 @@ class Affine(NIRNode):
     def __post_init__(self):
         assert len(self.weight.shape) >= 2, "Weight must be at least 2D"
         self.input_shape = {
-            "input": self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-2:]).T)
+            "input": self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-1:]).T)
         }
         self.output_shape = {
             "output": self.weight.shape[:-2] + (self.weight.shape[-2],)
@@ -240,15 +240,17 @@ class Flatten(NIRNode):
     end_dim: int = -1  # Last dimension to flatten
 
     def __post_init__(self):
+        assert len(self.input_shape.keys()) == 1, "Flatten only supports one input"
+        input_key = list(self.input_shape.keys())[0]
         if isinstance(self.input_shape, np.ndarray):
-            self.input_shape = {"input": self.input_shape}
-        concat = self.input_shape["input"][self.start_dim : self.end_dim].prod()
+            self.input_shape = {input_key: self.input_shape}
+        concat = self.input_shape[input_key][self.start_dim:self.end_dim].prod()
         self.output_shape = {
             "output": np.array(
                 [
-                    *self.input_shape["input"][: self.start_dim],
+                    *self.input_shape[input_key][:self.start_dim],
                     concat,
-                    *self.input_shape["input"][self.end_dim :],
+                    *self.input_shape[input_key][self.end_dim:],
                 ]
             )
         }
@@ -363,7 +365,7 @@ class Linear(NIRNode):
         assert len(self.weight.shape) >= 2, "Weight must be at least 2D"
         self.input_shape = {
             "input": np.array(
-                self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-2:]).T)
+                self.weight.shape[:-2] + tuple(np.array(self.weight.shape[-1:]).T)
             )
         }
         self.output_shape = {

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -40,7 +40,9 @@ class NIRGraph(NIRNode):
         """Create a sequential graph from a list of nodes by labelling them after
         indices."""
 
-        if len(nodes) > 0 and (isinstance(nodes[0], list) or isinstance(nodes[0], tuple)):
+        if len(nodes) > 0 and (
+            isinstance(nodes[0], list) or isinstance(nodes[0], tuple)
+        ):
             nodes = [*nodes[0]]
 
         def unique_node_name(node, counts):
@@ -227,7 +229,8 @@ class Flatten(NIRNode):
     This node flattens its input tensor.
     """
 
-    # Shape of input tensor (overrrides input_shape from NIRNode to allow for non-keyword (positional) initialization)
+    # Shape of input tensor (overrrides input_shape from
+    # NIRNode to allow for non-keyword (positional) initialization)
     input_shape: np.ndarray = field(kw_only=False)
     start_dim: int = 1  # First dimension to flatten
     end_dim: int = -1  # Last dimension to flatten
@@ -301,7 +304,8 @@ class Input(NIRNode):
     This is a virtual node, which allows feeding in data into the graph.
     """
 
-    # Shape of incoming data (overrrides input_shape from NIRNode to allow for non-keyword (positional) initialization)
+    # Shape of incoming data (overrrides input_shape from
+    # NIRNode to allow for non-keyword (positional) initialization)
     input_shape: np.ndarray = field(kw_only=False)
 
     def __post_init__(self):
@@ -398,7 +402,8 @@ class Output(NIRNode):
     Defines an output of the graph.
     """
 
-    # Shape of incoming data (overrrides input_shape from NIRNode to allow for non-keyword (positional) initialization)
+    # Shape of incoming data (overrrides input_shape from
+    # NIRNode to allow for non-keyword (positional) initialization)
     output_shape: np.ndarray = field(kw_only=False)
 
     def __post_init__(self):

--- a/nir/read.py
+++ b/nir/read.py
@@ -35,14 +35,13 @@ def read_node(node: typing.Any) -> nir.NIRNode:
             start_dim=node["start_dim"][()],
             end_dim=node["end_dim"][()],
             input_shape=node["input_shape"][()],
-            output_shape=node["output_shape"][()],
         )
     elif node["type"][()] == b"I":
         return nir.I(r=node["r"][()])
     elif node["type"][()] == b"IF":
         return nir.IF(r=node["r"][()], v_threshold=node["v_threshold"][()])
     elif node["type"][()] == b"Input":
-        return nir.Input(shape=node["shape"][()])
+        return nir.Input(input_shape=node["shape"][()])
     elif node["type"][()] == b"LI":
         return nir.LI(
             tau=node["tau"][()],
@@ -72,7 +71,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
             edges=node["edges"].asstr()[()],
         )
     elif node["type"][()] == b"Output":
-        return nir.Output(shape=node["shape"][()])
+        return nir.Output(output_shape=node["shape"][()])
     elif node["type"][()] == b"Scale":
         return nir.Scale(scale=node["scale"][()])
     elif node["type"][()] == b"Threshold":

--- a/nir/read.py
+++ b/nir/read.py
@@ -34,6 +34,8 @@ def read_node(node: typing.Any) -> nir.NIRNode:
         return nir.Flatten(
             start_dim=node["start_dim"][()],
             end_dim=node["end_dim"][()],
+            input_shape=node["input_shape"][()],
+            output_shape=node["output_shape"][()],
         )
     elif node["type"][()] == b"I":
         return nir.I(r=node["r"][()])

--- a/nir/read.py
+++ b/nir/read.py
@@ -68,7 +68,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
     elif node["type"][()] == b"NIRGraph":
         return nir.NIRGraph(
             nodes={k: read_node(n) for k, n in node["nodes"].items()},
-            edges=node["edges"].asstr()[()],
+            edges=[(a.decode("utf8"), b.decode("utf8")) for a, b in node["edges"][()]],
         )
     elif node["type"][()] == b"Output":
         return nir.Output(output_shape=node["shape"][()])

--- a/nir/read.py
+++ b/nir/read.py
@@ -34,14 +34,14 @@ def read_node(node: typing.Any) -> nir.NIRNode:
         return nir.Flatten(
             start_dim=node["start_dim"][()],
             end_dim=node["end_dim"][()],
-            input_shape=node["input_shape"][()],
+            input_shape={"input": node["input_shape"][()]},
         )
     elif node["type"][()] == b"I":
         return nir.I(r=node["r"][()])
     elif node["type"][()] == b"IF":
         return nir.IF(r=node["r"][()], v_threshold=node["v_threshold"][()])
     elif node["type"][()] == b"Input":
-        return nir.Input(input_shape=node["shape"][()])
+        return nir.Input(input_shape={"input": node["shape"][()]})
     elif node["type"][()] == b"LI":
         return nir.LI(
             tau=node["tau"][()],
@@ -71,7 +71,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
             edges=[(a.decode("utf8"), b.decode("utf8")) for a, b in node["edges"][()]],
         )
     elif node["type"][()] == b"Output":
-        return nir.Output(output_shape=node["shape"][()])
+        return nir.Output(output_shape={"output": node["shape"][()]})
     elif node["type"][()] == b"Scale":
         return nir.Scale(scale=node["scale"][()])
     elif node["type"][()] == b"Threshold":

--- a/nir/write.py
+++ b/nir/write.py
@@ -41,6 +41,8 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "type": "Flatten",
             "start_dim": node.start_dim,
             "end_dim": node.end_dim,
+            "input_shape": node.input_shape,
+            "output_shape": node.output_shape,
         }
     elif isinstance(node, nir.I):
         return {"type": "I", "r": node.r}

--- a/nir/write.py
+++ b/nir/write.py
@@ -41,7 +41,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "type": "Flatten",
             "start_dim": node.start_dim,
             "end_dim": node.end_dim,
-            "input_shape": node.input_shape,
+            "input_shape": node.input_shape["input"],
         }
     elif isinstance(node, nir.I):
         return {"type": "I", "r": node.r}
@@ -52,7 +52,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "v_threshold": node.v_threshold,
         }
     elif isinstance(node, nir.Input):
-        return {"type": "Input", "shape": node.input_shape}
+        return {"type": "Input", "shape": node.input_shape["input"]}
     elif isinstance(node, nir.LI):
         return {
             "type": "LI",
@@ -86,7 +86,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "edges": node.edges,
         }
     elif isinstance(node, nir.Output):
-        return {"type": "Output", "shape": node.output_shape}
+        return {"type": "Output", "shape": node.output_shape["output"]}
     elif isinstance(node, nir.Scale):
         return {"type": "Scale", "scale": node.scale}
     elif isinstance(node, nir.Threshold):

--- a/nir/write.py
+++ b/nir/write.py
@@ -42,7 +42,6 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "start_dim": node.start_dim,
             "end_dim": node.end_dim,
             "input_shape": node.input_shape,
-            "output_shape": node.output_shape,
         }
     elif isinstance(node, nir.I):
         return {"type": "I", "r": node.r}
@@ -53,7 +52,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "v_threshold": node.v_threshold,
         }
     elif isinstance(node, nir.Input):
-        return {"type": "Input", "shape": node.shape}
+        return {"type": "Input", "shape": node.input_shape}
     elif isinstance(node, nir.LI):
         return {
             "type": "LI",
@@ -87,7 +86,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "edges": node.edges,
         }
     elif isinstance(node, nir.Output):
-        return {"type": "Output", "shape": node.shape}
+        return {"type": "Output", "shape": node.output_shape}
     elif isinstance(node, nir.Scale):
         return {"type": "Scale", "scale": node.scale}
     elif isinstance(node, nir.Threshold):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+import nir
+
+def mock_linear(*shape):
+    return nir.Linear(weight=np.random.randn(*shape).T)
+
+
+def mock_affine(*shape):
+    return nir.Affine(weight=np.random.randn(*shape).T, bias=np.random.randn(shape[1]))
+
+
+def mock_input(*shape):
+    return nir.Input(input_shape=np.array(shape))
+
+
+def mock_integrator(*shape):
+    return nir.I(r=np.random.randn(*shape))
+
+
+def mock_output(*shape):
+    return nir.Output(output_shape=np.array(shape))
+
+
+def mock_delay(*shape):
+    return nir.Delay(delay=np.random.randn(*shape))
+

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import nir
 
+
 def mock_linear(*shape):
     return nir.Linear(weight=np.random.randn(*shape).T)
 
@@ -24,4 +25,3 @@ def mock_output(*shape):
 
 def mock_delay(*shape):
     return nir.Delay(delay=np.random.randn(*shape))
-

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -1,6 +1,8 @@
+import numpy as np
+
 import nir
 from .test_readwrite import factory_test_graph
-from tests import *
+from tests import mock_affine
 
 
 def test_sequential():

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -1,59 +1,90 @@
 import nir
 from .test_readwrite import factory_test_graph
+from tests import *
 
-    
+
 def test_sequential():
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    b = nir.Delay([0.5, 0.1, 0.2])
-    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
-    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
- 
+    a = mock_affine(2, 2)
+    b = nir.Delay(np.array([0.5, 0.1, 0.2]))
+    c = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
+    d = mock_affine(3, 2)
+
     ir = nir.NIRGraph.from_list(a, b, c, d)
     factory_test_graph(ir)
 
+
 def test_two_independent_branches():
-   
     # Branch 1
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    b = nir.Delay([0.5, 0.1, 0.2])
-    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
-    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
- 
+    a = mock_affine(2, 3)
+    b = nir.Delay(np.array([0.5, 0.1, 0.2]))
+    c = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
+    d = mock_affine(2, 3)
+
     branch_1 = nir.NIRGraph.from_list(a, b, c, d)
-    
+
     # Branch 2
-    e = nir.Affine(weight=[1, 2], bias=[0, 0])
-    f = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
-    g = nir.Affine(weight=[[1, 0], [0, 2]], bias=[1, 1])
-    
+    e = mock_affine(2, 3)
+    f = nir.LIF(
+        tau=np.array([10, 20]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 2]),
+    )
+    g = mock_affine(3, 2)
+
     branch_2 = nir.NIRGraph.from_list(e, f, g)
- 
+
     ir = nir.NIRGraph(
         nodes={"branch_1": branch_1, "branch_2": branch_2},
         edges=[],
     )
     factory_test_graph(ir)
 
+
 def test_two_independent_branches_merging():
-   
     # Branch 1
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    b = nir.Delay([0.5, 0.1, 0.2])
-    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
-    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
- 
+    a = mock_affine(2, 3)
+    b = nir.Delay(np.array([0.5, 0.1, 0.2]))
+    c = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
+    d = mock_affine(2, 3)
+
     branch_1 = nir.NIRGraph.from_list(a, b, c, d)
-    
+
     # Branch 2
-    e = nir.Affine(weight=[1, 2], bias=[0, 0])
-    f = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
-    g = nir.Affine(weight=[[1, 0], [0, 2]], bias=[1, 1])
-    
+    e = mock_affine(2, 3)
+    f = nir.LIF(
+        tau=np.array([10, 20]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 2]),
+    )
+    g = mock_affine(3, 2)
+
     branch_2 = nir.NIRGraph.from_list(e, f, g)
- 
+
     # Junction
     # TODO: This should be a node that accepts two inputs
-    h = nir.LIF(tau=[5, 2], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1]) 
+    h = nir.LIF(
+        tau=np.array([5, 2]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 1]),
+    )
 
     ir = nir.NIRGraph(
         nodes={"branch_1": branch_1, "branch_2": branch_2, "junction": h},
@@ -61,184 +92,211 @@ def test_two_independent_branches_merging():
     )
     factory_test_graph(ir)
 
-def merge_and_split_single_output():
+
+def test_merge_and_split_single_output():
     # Part before split
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    a = mock_affine(2, 3)
+    b = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
     pre_split = nir.NIRGraph.from_list(a, b)
 
-    # Branch 1 
-    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
-    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    # Branch 1
+    c = mock_affine(2, 3)
+    d = nir.LIF(
+        tau=np.array([10, 20]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 2]),
+    )
     branch_1 = nir.NIRGraph.from_list(c, d)
-    expand_1 = nir.Project(output_indices=[0, float("nan")])
 
     # Branch 2
-    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
-    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
+    e = mock_affine(2, 3)
+    f = nir.LIF(
+        tau=np.array([15, 5]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 1]),
+    )
     branch_2 = nir.NIRGraph.from_list([e, f])
-    expand_2 = nir.Project(output_indices=[float("nan"), 1])
 
     # Junction
     # TODO: This should be a node that accepts two inputs
-    g = nir.Affine(weight=[[2, 0], [1, 3], [4, 1]], bias=[0, 1])
+    g = nir.Affine(weight=np.array([[2, 0], [1, 3], [4, 1]]), bias=np.array([0, 1]))
 
-    nodes={
+    nodes = {
         "pre_split": pre_split,
-        "branch_1": branch_1, 
-        "branch_2": branch_2, 
-        "expand_1": expand_1,
-        "expand_2": expand_2,
+        "branch_1": branch_1,
+        "branch_2": branch_2,
         "junction": g,
     }
-    edges=[
+    edges = [
         ("pre_split", "branch_1"),
         ("pre_split", "branch_2"),
-        ("branch_1", "expand_1"), 
-        ("expand_1", "junction"), 
-        ("branch_2", "expand_2"), 
-        ("expand_2", "junction"), 
+        ("branch_1", "junction"),
+        ("branch_2", "junction"),
     ]
     ir = nir.NIRGraph(nodes=nodes, edges=edges)
     factory_test_graph(ir)
 
+
 def merge_and_split_different_outputs():
     # Part before split
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    #TODO: This should be a node with two outputs
-    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    a = mock_affine(3, 2)
+    # TODO: This should be a node with two outputs
+    b = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
     pre_split = nir.NIRGraph.from_list([a, b])
 
-    # Branch 1 
+    # Branch 1
     reduce_1 = nir.Project(output_indices=[0])
-    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
-    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    c = mock_affine(3, 2)
+    d = nir.LIF(
+        tau=np.array([10, 20]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 2]),
+    )
     branch_1 = nir.NIRGraph.from_list([c, d])
     expand_1 = nir.Project(output_indices=[0, float("nan")])
 
     # Branch 2
     reduce_2 = nir.Project(output_indices=[1])
-    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
-    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
+    e = mock_affine(3, 2)
+    f = nir.LIF(
+        tau=np.array([15, 5]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 1]),
+    )
     branch_2 = nir.NIRGraph.from_list([e, f])
     expand_2 = nir.Project(output_indices=[float("nan"), 1])
 
     # Junction
     # TODO: This should be a node that accepts two inputs
-    g = nir.Affine(weight=[[2, 0], [1, 3], [4, 1]], bias=[0, 1])
+    g = mock_affine(3, 2)
 
-    nodes={
+    nodes = {
         "pre_split": pre_split,
         "reduce_1": reduce_1,
         "reduce_2": reduce_2,
-        "branch_1": branch_1, 
-        "branch_2": branch_2, 
+        "branch_1": branch_1,
+        "branch_2": branch_2,
         "expand_1": expand_1,
         "expand_2": expand_2,
         "junction": g,
     }
-    edges=[
+    edges = [
         ("pre_split", "reduce_1"),
         ("pre_split", "reduce_2"),
         ("reduce_1", "branch_1"),
         ("reduce_2", "branch_2"),
-        ("branch_1", "expand_1"), 
-        ("expand_1", "junction"), 
-        ("branch_2", "expand_2"), 
-        ("expand_2", "junction"), 
+        ("branch_1", "expand_1"),
+        ("expand_1", "junction"),
+        ("branch_2", "expand_2"),
+        ("expand_2", "junction"),
     ]
     ir = nir.NIRGraph(nodes=nodes, edges=edges)
     factory_test_graph(ir)
+
 
 def test_residual():
     # Part before split
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    a = mock_affine(2, 3)
 
     # Residual block
-    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
-    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
-    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    b = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
+    c = mock_affine(3, 2)
+    d = nir.LIF(
+        tau=np.array([10, 20]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 2]),
+    )
 
     # Junction
-    expand_a = nir.Project(output_indices=[0, float("nan")])
-    expand_d = nir.Project(output_indices=[float("nan"), 1])
     # TODO: This should be a node that accepts two inputs
-    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
-    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
-    
-    nodes={
+    e = mock_affine(3, 2)
+    f = nir.LIF(
+        tau=np.array([15, 5]),
+        r=np.array([1, 1]),
+        v_leak=np.array([0, 0]),
+        v_threshold=np.array([1, 1]),
+    )
+
+    nodes = {
         "a": a,
         "b": b,
         "c": c,
-        "d": d, 
-        "expand_a": expand_a,
-        "expand_d": expand_d,
+        "d": d,
         "e": e,
         "f": f,
     }
-    edges=[
+    edges = [
         ("a", "b"),
-        ("a", "expand_a"),
         ("b", "c"),
-        ("d", "expand_d"),
-        ("reduce_2", "branch_2"),
-        ("branch_1", "expand_1"), 
-        ("expand_1", "e"), 
-        ("expand_2", "e"), 
-        ("e", "f"), 
+        ("c", "d"),
+        ("d", "e"),
+        ("a", "e"),
+        ("e", "f"),
     ]
     ir = nir.NIRGraph(nodes=nodes, edges=edges)
     factory_test_graph(ir)
 
+
 def test_complex():
-    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
-    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
-    expand_b = nir.Project([0, float("nan")])
-    c = nir.LIF(tau=[5, 20, 1], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 1, 1])
-    c_first = nir.Project([0])
-    c_second = nir.Project([1])
-    expand_c = nir.Project([float("nan"), 1])
+    a = nir.Affine(weight=np.array([[1, 2, 3]]), bias=np.array([[0, 0, 0]]))
+    b = nir.LIF(
+        tau=np.array([10, 20, 30]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 2, 3]),
+    )
+    c = nir.LIF(
+        tau=np.array([5, 20, 1]),
+        r=np.array([1, 1, 1]),
+        v_leak=np.array([0, 0, 0]),
+        v_threshold=np.array([1, 1, 1]),
+    )
     # TODO: This should be a node that accepts two inputs
     d = nir.Affine(
-        weight=[[[1, 3], [2, 3], [1, 4]], [[2, 3], [1, 2], [1, 4]]],
-        bias=[0, 0]
+        weight=np.array([[[1, 3], [2, 3], [1, 4]], [[2, 3], [1, 2], [1, 4]]]),
+        bias=np.array([0, 0]),
     )
-    expand_d = nir.Project([0, float("nan")])
-    e = nir.Affine(weight=[[1, 3], [2, 3], [1, 4]], bias=[0, 0])
-    expand_e = nir.Project([float("nan"), 1])
+    e = nir.Affine(weight=np.array([[1, 3], [2, 3], [1, 4]]), bias=np.array([0, 0]))
     # TODO: This should be a node that accepts two inputs
     f = nir.Affine(
-        weight=[[[1, 3], [1, 4]], [[2, 3], [3, 4]]],
-        bias=[0, 0]
+        weight=np.array([[[1, 3], [1, 4]], [[2, 3], [3, 4]]]), bias=np.array([0, 0])
     )
-    nodes={
+    nodes = {
         "a": a,
         "b": b,
-        "expand_b": expand_b,
         "c": c,
-        "c_first": c_first,
-        "c_second": c_second,
-        "expand_c": expand_c,
-        "d": d, 
-        "expand_d": expand_d,
+        "d": d,
         "e": e,
-        "expand_e": expand_e,
         "f": f,
     }
-    edges=[
+    edges = [
         ("a", "b"),
         ("a", "c"),
-        ("b", "expand_b"),
-        ("expand_b", "d"),
-        ("c", "c_first"),
-        ("c_first", "expand_c"),
-        ("expand_c", "d"),
-        ("c", "c_second"),
-        ("c_second", "e"),
-        ("d", "expand_d"),
-        ("e", "expand_e"),
-        ("expand_d", "f"), 
-        ("expand_e", "f"), 
+        ("b", "d"),
+        ("c", "d"),
+        ("c", "e"),
+        ("d", "f"),
+        ("e", "f"),
     ]
     ir = nir.NIRGraph(nodes=nodes, edges=edges)
     factory_test_graph(ir)

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -1,0 +1,244 @@
+import nir
+from .test_readwrite import factory_test_graph
+
+    
+def test_sequential():
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    b = nir.Delay([0.5, 0.1, 0.2])
+    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+ 
+    ir = nir.NIRGraph.from_list(a, b, c, d)
+    factory_test_graph(ir)
+
+def test_two_independent_branches():
+   
+    # Branch 1
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    b = nir.Delay([0.5, 0.1, 0.2])
+    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+ 
+    branch_1 = nir.NIRGraph.from_list(a, b, c, d)
+    
+    # Branch 2
+    e = nir.Affine(weight=[1, 2], bias=[0, 0])
+    f = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    g = nir.Affine(weight=[[1, 0], [0, 2]], bias=[1, 1])
+    
+    branch_2 = nir.NIRGraph.from_list(e, f, g)
+ 
+    ir = nir.NIRGraph(
+        nodes={"branch_1": branch_1, "branch_2": branch_2},
+        edges=[],
+    )
+    factory_test_graph(ir)
+
+def test_two_independent_branches_merging():
+   
+    # Branch 1
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    b = nir.Delay([0.5, 0.1, 0.2])
+    c = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    d = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+ 
+    branch_1 = nir.NIRGraph.from_list(a, b, c, d)
+    
+    # Branch 2
+    e = nir.Affine(weight=[1, 2], bias=[0, 0])
+    f = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    g = nir.Affine(weight=[[1, 0], [0, 2]], bias=[1, 1])
+    
+    branch_2 = nir.NIRGraph.from_list(e, f, g)
+ 
+    # Junction
+    # TODO: This should be a node that accepts two inputs
+    h = nir.LIF(tau=[5, 2], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1]) 
+
+    ir = nir.NIRGraph(
+        nodes={"branch_1": branch_1, "branch_2": branch_2, "junction": h},
+        edges=[("branch_1", "junction"), ("branch_2", "junction")],
+    )
+    factory_test_graph(ir)
+
+def merge_and_split_single_output():
+    # Part before split
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    pre_split = nir.NIRGraph.from_list(a, b)
+
+    # Branch 1 
+    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    branch_1 = nir.NIRGraph.from_list(c, d)
+    expand_1 = nir.Project(output_indices=[0, float("nan")])
+
+    # Branch 2
+    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
+    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
+    branch_2 = nir.NIRGraph.from_list([e, f])
+    expand_2 = nir.Project(output_indices=[float("nan"), 1])
+
+    # Junction
+    # TODO: This should be a node that accepts two inputs
+    g = nir.Affine(weight=[[2, 0], [1, 3], [4, 1]], bias=[0, 1])
+
+    nodes={
+        "pre_split": pre_split,
+        "branch_1": branch_1, 
+        "branch_2": branch_2, 
+        "expand_1": expand_1,
+        "expand_2": expand_2,
+        "junction": g,
+    }
+    edges=[
+        ("pre_split", "branch_1"),
+        ("pre_split", "branch_2"),
+        ("branch_1", "expand_1"), 
+        ("expand_1", "junction"), 
+        ("branch_2", "expand_2"), 
+        ("expand_2", "junction"), 
+    ]
+    ir = nir.NIRGraph(nodes=nodes, edges=edges)
+    factory_test_graph(ir)
+
+def merge_and_split_different_outputs():
+    # Part before split
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    #TODO: This should be a node with two outputs
+    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    pre_split = nir.NIRGraph.from_list([a, b])
+
+    # Branch 1 
+    reduce_1 = nir.Project(output_indices=[0])
+    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+    branch_1 = nir.NIRGraph.from_list([c, d])
+    expand_1 = nir.Project(output_indices=[0, float("nan")])
+
+    # Branch 2
+    reduce_2 = nir.Project(output_indices=[1])
+    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
+    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
+    branch_2 = nir.NIRGraph.from_list([e, f])
+    expand_2 = nir.Project(output_indices=[float("nan"), 1])
+
+    # Junction
+    # TODO: This should be a node that accepts two inputs
+    g = nir.Affine(weight=[[2, 0], [1, 3], [4, 1]], bias=[0, 1])
+
+    nodes={
+        "pre_split": pre_split,
+        "reduce_1": reduce_1,
+        "reduce_2": reduce_2,
+        "branch_1": branch_1, 
+        "branch_2": branch_2, 
+        "expand_1": expand_1,
+        "expand_2": expand_2,
+        "junction": g,
+    }
+    edges=[
+        ("pre_split", "reduce_1"),
+        ("pre_split", "reduce_2"),
+        ("reduce_1", "branch_1"),
+        ("reduce_2", "branch_2"),
+        ("branch_1", "expand_1"), 
+        ("expand_1", "junction"), 
+        ("branch_2", "expand_2"), 
+        ("expand_2", "junction"), 
+    ]
+    ir = nir.NIRGraph(nodes=nodes, edges=edges)
+    factory_test_graph(ir)
+
+def test_residual():
+    # Part before split
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+
+    # Residual block
+    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    c = nir.Affine(weight=[[1, 0], [0, 2], [1, 1]], bias=[1, 1])
+    d = nir.LIF(tau=[10, 20], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 2])
+
+    # Junction
+    expand_a = nir.Project(output_indices=[0, float("nan")])
+    expand_d = nir.Project(output_indices=[float("nan"), 1])
+    # TODO: This should be a node that accepts two inputs
+    e = nir.Affine(weight=[[2, 4], [1, 0], [0, 1]], bias=[2, 1])
+    f = nir.LIF(tau=[15, 5], r=[1, 1], v_leak=[0, 0], v_threshold=[1, 1])
+    
+    nodes={
+        "a": a,
+        "b": b,
+        "c": c,
+        "d": d, 
+        "expand_a": expand_a,
+        "expand_d": expand_d,
+        "e": e,
+        "f": f,
+    }
+    edges=[
+        ("a", "b"),
+        ("a", "expand_a"),
+        ("b", "c"),
+        ("d", "expand_d"),
+        ("reduce_2", "branch_2"),
+        ("branch_1", "expand_1"), 
+        ("expand_1", "e"), 
+        ("expand_2", "e"), 
+        ("e", "f"), 
+    ]
+    ir = nir.NIRGraph(nodes=nodes, edges=edges)
+    factory_test_graph(ir)
+
+def test_complex():
+    a = nir.Affine(weight=[1, 2, 3], bias=[0, 0, 0])
+    b = nir.LIF(tau=[10, 20, 30], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 2, 3])
+    expand_b = nir.Project([0, float("nan")])
+    c = nir.LIF(tau=[5, 20, 1], r=[1, 1, 1], v_leak=[0, 0, 0], v_threshold=[1, 1, 1])
+    c_first = nir.Project([0])
+    c_second = nir.Project([1])
+    expand_c = nir.Project([float("nan"), 1])
+    # TODO: This should be a node that accepts two inputs
+    d = nir.Affine(
+        weight=[[[1, 3], [2, 3], [1, 4]], [[2, 3], [1, 2], [1, 4]]],
+        bias=[0, 0]
+    )
+    expand_d = nir.Project([0, float("nan")])
+    e = nir.Affine(weight=[[1, 3], [2, 3], [1, 4]], bias=[0, 0])
+    expand_e = nir.Project([float("nan"), 1])
+    # TODO: This should be a node that accepts two inputs
+    f = nir.Affine(
+        weight=[[[1, 3], [1, 4]], [[2, 3], [3, 4]]],
+        bias=[0, 0]
+    )
+    nodes={
+        "a": a,
+        "b": b,
+        "expand_b": expand_b,
+        "c": c,
+        "c_first": c_first,
+        "c_second": c_second,
+        "expand_c": expand_c,
+        "d": d, 
+        "expand_d": expand_d,
+        "e": e,
+        "expand_e": expand_e,
+        "f": f,
+    }
+    edges=[
+        ("a", "b"),
+        ("a", "c"),
+        ("b", "expand_b"),
+        ("expand_b", "d"),
+        ("c", "c_first"),
+        ("c_first", "expand_c"),
+        ("expand_c", "d"),
+        ("c", "c_second"),
+        ("c_second", "e"),
+        ("d", "expand_d"),
+        ("e", "expand_e"),
+        ("expand_d", "f"), 
+        ("expand_e", "f"), 
+    ]
+    ir = nir.NIRGraph(nodes=nodes, edges=edges)
+    factory_test_graph(ir)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -109,9 +109,14 @@ def test_linear():
 def test_flatten():
     ir = nir.NIRGraph(
         nodes={
-            "in": nir.Input(np.array([4, 5, 2])),
-            "flat": nir.Flatten(0),
-            "out": nir.Output(np.array([20, 2])),
+            "in": nir.Input(shape=np.array([4, 5, 2])),
+            "flat": nir.Flatten(
+                start_dim=0,
+                end_dim=0,
+                input_shape=np.array([4, 5, 2]),
+                output_shape=np.array([20, 2]),
+            ),
+            "out": nir.Output(shape=np.array([20, 2])),
         },
         edges=[("in", "flat"), ("flat", "out")],
     )

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -112,7 +112,9 @@ def test_flatten():
             "flat": nir.Flatten(
                 start_dim=0,
                 end_dim=0,
-                input_shape=np.array([4, 5, 2]),
+                input_shape={
+                    'input': np.array([4, 5, 2])
+                }
             ),
             "out": nir.Output(output_shape=np.array([20, 2])),
         },
@@ -151,7 +153,7 @@ def test_from_list_naming():
     assert "affine_2" in ir.nodes.keys()
     assert "affine_3" in ir.nodes.keys()
     assert "output" in ir.nodes.keys()
-    assert np.allclose(ir.nodes["input"].input_shape["input"], [3, 2])
+    assert np.allclose(ir.nodes["input"].input_shape["input"], [2])
     assert np.allclose(ir.nodes["linear"].weight, np.array([[3, 1], [-1, 2], [1, 2]]))
     assert np.allclose(
         ir.nodes["linear_1"].weight, np.array([[3, 1], [-1, 4], [1, 2]]).T
@@ -172,6 +174,7 @@ def test_from_list_naming():
         ir.nodes["affine_3"].weight, np.array([[2, 1], [-1, 3], [1, 2]]).T
     )
     assert np.allclose(ir.nodes["affine_3"].bias, np.array([-2, 3]))
+    print(ir.nodes['output'].input_shape['input'])
     assert np.allclose(ir.nodes["output"].input_shape["input"], [2])
     assert ir.edges == [
         ("input", "linear"),
@@ -213,11 +216,11 @@ def test_subgraph_merge():
         nodes={"L": g1, "R": g2, "E": end},
         edges=[("L.output", "E.input"), ("R.output", "E.input")],
     )
-    assert np.allclose(g.nodes["L"].nodes["linear"].input_shape["input"], (3, 2))
-    assert np.allclose(g.nodes["L"].nodes["linear_1"].input_shape["input"], (2, 3))
-    assert np.allclose(g.nodes["R"].nodes["linear"].input_shape["input"], (3, 1))
-    assert np.allclose(g.nodes["R"].nodes["linear_1"].input_shape["input"], (2, 3))
-    assert np.allclose(g.nodes["E"].input_shape["input"], (2,))
+    assert np.allclose(g.nodes["L"].nodes["linear"].input_shape["input"], [2])
+    assert np.allclose(g.nodes["L"].nodes["linear_1"].input_shape["input"], [3])
+    assert np.allclose(g.nodes["R"].nodes["linear"].input_shape["input"], [1])
+    assert np.allclose(g.nodes["R"].nodes["linear_1"].input_shape["input"], [3])
+    assert np.allclose(g.nodes["E"].input_shape["input"], [2])
     assert g.edges == [("L.output", "E.input"), ("R.output", "E.input")]
     assert g.nodes["L"].edges == [
         ("input", "linear"),

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -56,9 +56,7 @@ def test_simple_with_input_output():
         },
         edges=[("in", "w"), ("w", "out")],
     )
-    assert ir.nodes["in"].input_shape == [
-        3,
-    ]
+    assert ir.nodes["in"].input_shape == {"input": np.array([3])}
     assert np.allclose(ir.nodes["w"].weight, a.weight)
     assert np.allclose(ir.nodes["w"].bias, a.bias)
     assert ir.edges == [("in", "w"), ("w", "out")]
@@ -74,9 +72,7 @@ def test_delay():
         },
         edges=[("in", "d"), ("d", "out")],
     )
-    assert ir.nodes["in"].input_shape == [
-        3,
-    ]
+    assert ir.nodes["in"].input_shape == {"input": np.array([3])}
     assert np.allclose(ir.nodes["d"].delay, d.delay)
     assert ir.edges == [("in", "d"), ("d", "out")]
 
@@ -97,9 +93,7 @@ def test_threshold():
         },
         edges=[("in", "thr"), ("thr", "out")],
     )
-    assert ir.nodes["in"].input_shape == [
-        3,
-    ]
+    assert ir.nodes["in"].input_shape == {"input": np.array([3])}
     assert np.allclose(ir.nodes["thr"].threshold, threshold)
     assert ir.edges == [("in", "thr"), ("thr", "out")]
 
@@ -124,8 +118,8 @@ def test_flatten():
         },
         edges=[("in", "flat"), ("flat", "out")],
     )
-    assert np.allclose(ir.nodes["in"].input_shape, [4, 5, 2])
-    assert np.allclose(ir.nodes["out"].input_shape, [20, 2])
+    assert np.allclose(ir.nodes["in"].input_shape["input"], np.array([4, 5, 2]))
+    assert np.allclose(ir.nodes["out"].input_shape["input"], np.array([20, 2]))
 
 
 def test_from_list_naming():
@@ -157,7 +151,7 @@ def test_from_list_naming():
     assert "affine_2" in ir.nodes.keys()
     assert "affine_3" in ir.nodes.keys()
     assert "output" in ir.nodes.keys()
-    assert np.allclose(ir.nodes["input"].input_shape, [3, 2])
+    assert np.allclose(ir.nodes["input"].input_shape["input"], [3, 2])
     assert np.allclose(ir.nodes["linear"].weight, np.array([[3, 1], [-1, 2], [1, 2]]))
     assert np.allclose(
         ir.nodes["linear_1"].weight, np.array([[3, 1], [-1, 4], [1, 2]]).T
@@ -178,7 +172,7 @@ def test_from_list_naming():
         ir.nodes["affine_3"].weight, np.array([[2, 1], [-1, 3], [1, 2]]).T
     )
     assert np.allclose(ir.nodes["affine_3"].bias, np.array([-2, 3]))
-    assert np.allclose(ir.nodes["output"].input_shape, [2])
+    assert np.allclose(ir.nodes["output"].input_shape["input"], [2])
     assert ir.edges == [
         ("input", "linear"),
         ("linear", "linear_1"),
@@ -219,11 +213,11 @@ def test_subgraph_merge():
         nodes={"L": g1, "R": g2, "E": end},
         edges=[("L.output", "E.input"), ("R.output", "E.input")],
     )
-    assert np.allclose(g.nodes["L"].nodes["linear"].input_shape, (3, 2))
-    assert np.allclose(g.nodes["L"].nodes["linear_1"].input_shape, (2, 3))
-    assert np.allclose(g.nodes["R"].nodes["linear"].input_shape, (3, 1))
-    assert np.allclose(g.nodes["R"].nodes["linear_1"].input_shape, (2, 3))
-    assert np.allclose(g.nodes["E"].input_shape, (2,))
+    assert np.allclose(g.nodes["L"].nodes["linear"].input_shape["input"], (3, 2))
+    assert np.allclose(g.nodes["L"].nodes["linear_1"].input_shape["input"], (2, 3))
+    assert np.allclose(g.nodes["R"].nodes["linear"].input_shape["input"], (3, 1))
+    assert np.allclose(g.nodes["R"].nodes["linear_1"].input_shape["input"], (2, 3))
+    assert np.allclose(g.nodes["E"].input_shape["input"], (2,))
     assert g.edges == [("L.output", "E.input"), ("R.output", "E.input")]
     assert g.nodes["L"].edges == [
         ("input", "linear"),

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -210,6 +210,16 @@ def test_from_list_naming():
     ]
 
 
+def test_from_list_tuple_or_list():
+    nodes = [mock_affine(2, 3), mock_delay(1)]
+    assert len(nir.NIRGraph.from_list(*nodes).nodes) == 4
+    assert len(nir.NIRGraph.from_list(*nodes).edges) == 3
+    assert len(nir.NIRGraph.from_list(tuple(nodes)).nodes) == 4
+    assert len(nir.NIRGraph.from_list(tuple(nodes)).nodes) == 4
+    assert len(nir.NIRGraph.from_list(nodes[0], nodes[1]).edges) == 3
+    assert len(nir.NIRGraph.from_list(nodes[0], nodes[1]).edges) == 3
+
+
 def test_subgraph_merge():
     """
     ```mermaid
@@ -231,7 +241,7 @@ def test_subgraph_merge():
     assert np.allclose(g.nodes["L"].nodes["linear_1"].input_shape, (2, 3))
     assert np.allclose(g.nodes["R"].nodes["linear"].input_shape, (3, 1))
     assert np.allclose(g.nodes["R"].nodes["linear_1"].input_shape, (2, 3))
-    assert np.allclose(g.nodes["E"].input_shape,  (2,))
+    assert np.allclose(g.nodes["E"].input_shape, (2,))
     assert g.edges == [("L.output", "E.input"), ("R.output", "E.input")]
     assert g.nodes["L"].edges == [
         ("input", "linear"),
@@ -243,4 +253,3 @@ def test_subgraph_merge():
         ("linear", "linear_1"),
         ("linear_1", "output"),
     ]
-

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -1,31 +1,13 @@
 import numpy as np
 
 import nir
-from tests import *
-
-
-def mock_linear(*shape):
-    return nir.Linear(weight=np.random.randn(*shape).T)
-
-
-def mock_affine(*shape):
-    return nir.Affine(weight=np.random.randn(*shape).T, bias=np.random.randn(shape[1]))
-
-
-def mock_input(*shape):
-    return nir.Input(input_shape=np.array(shape))
-
-
-def mock_integrator(*shape):
-    return nir.I(r=np.random.randn(*shape))
-
-
-def mock_output(*shape):
-    return nir.Output(output_shape=np.array(shape))
-
-
-def mock_delay(*shape):
-    return nir.Delay(delay=np.random.randn(*shape))
+from tests import (
+    mock_delay,
+    mock_affine,
+    mock_integrator,
+    mock_linear,
+    mock_output,
+)
 
 
 def test_has_version():
@@ -34,10 +16,10 @@ def test_has_version():
 
 
 def test_simple():
-    l = mock_affine(4, 3)
-    ir = nir.NIRGraph(nodes={"a": l}, edges=[("a", "a")])
-    assert np.allclose(ir.nodes["a"].weight, l.weight)
-    assert np.allclose(ir.nodes["a"].bias, l.bias)
+    a = mock_affine(4, 3)
+    ir = nir.NIRGraph(nodes={"a": a}, edges=[("a", "a")])
+    assert np.allclose(ir.nodes["a"].weight, a.weight)
+    assert np.allclose(ir.nodes["a"].bias, a.bias)
     assert ir.edges == [("a", "a")]
 
 
@@ -123,9 +105,9 @@ def test_threshold():
 
 
 def test_linear():
-    l = mock_linear(3, 3)
-    ir = nir.NIRGraph(nodes={"a": l}, edges=[("a", "a")])
-    assert np.allclose(ir.nodes["a"].weight, l.weight)
+    a = mock_linear(3, 3)
+    ir = nir.NIRGraph(nodes={"a": a}, edges=[("a", "a")])
+    assert np.allclose(ir.nodes["a"].weight, a.weight)
     assert ir.edges == [("a", "a")]
 
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -110,11 +110,7 @@ def test_flatten():
         nodes={
             "in": nir.Input(input_shape=np.array([4, 5, 2])),
             "flat": nir.Flatten(
-                start_dim=0,
-                end_dim=0,
-                input_shape={
-                    'input': np.array([4, 5, 2])
-                }
+                start_dim=0, end_dim=0, input_shape={"input": np.array([4, 5, 2])}
             ),
             "out": nir.Output(output_shape=np.array([20, 2])),
         },
@@ -174,7 +170,7 @@ def test_from_list_naming():
         ir.nodes["affine_3"].weight, np.array([[2, 1], [-1, 3], [1, 2]]).T
     )
     assert np.allclose(ir.nodes["affine_3"].bias, np.array([-2, 3]))
-    print(ir.nodes['output'].input_shape['input'])
+    print(ir.nodes["output"].input_shape["input"])
     assert np.allclose(ir.nodes["output"].input_shape["input"], [2])
     assert ir.edges == [
         ("input", "linear"),

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -168,7 +168,7 @@ def test_flatten():
         nir.Flatten(
             start_dim=0,
             end_dim=0,
-            input_shape=np.array([2, 3]),
+            input_shape={'input': np.array([2, 3])},
         ),
         nir.Output(output_shape=np.array([6])),
     )

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -3,7 +3,7 @@ import tempfile
 import numpy as np
 
 import nir
-from tests import *
+from tests import mock_affine
 
 
 def assert_equivalence(ir: nir.NIRGraph, ir2: nir.NIRGraph):

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -14,7 +14,11 @@ def assert_equivalence(ir: nir.NIRGraph, ir2: nir.NIRGraph):
             assert_equivalence(ir.nodes[ik], ir2.nodes[ik])
         else:
             for k, v in ir.nodes[ik].__dict__.items():
-                if isinstance(v, np.ndarray) or isinstance(v, list) or isinstance(v, tuple):
+                if (
+                    isinstance(v, np.ndarray)
+                    or isinstance(v, list)
+                    or isinstance(v, tuple)
+                ):
                     assert np.array_equal(v, getattr(ir2.nodes[ik], k))
                 else:
                     assert v == getattr(ir2.nodes[ik], k)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -20,6 +20,10 @@ def assert_equivalence(ir: nir.NIRGraph, ir2: nir.NIRGraph):
                     or isinstance(v, tuple)
                 ):
                     assert np.array_equal(v, getattr(ir2.nodes[ik], k))
+                elif isinstance(v, dict):
+                    d = getattr(ir2.nodes[ik], k)
+                    for a, b in d.items():
+                        assert np.array_equal(v[a], b)
                 else:
                     assert v == getattr(ir2.nodes[ik], k)
     for i, _ in enumerate(ir.edges):

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -168,7 +168,7 @@ def test_flatten():
         nir.Flatten(
             start_dim=0,
             end_dim=0,
-            input_shape={'input': np.array([2, 3])},
+            input_shape={"input": np.array([2, 3])},
         ),
         nir.Output(output_shape=np.array([6])),
     )

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -40,7 +40,7 @@ def test_nested():
     i = np.array([1, 1])
     nested = nir.NIRGraph(
         nodes={
-            "a": nir.I(r=[1, 1]),
+            "a": nir.I(r=np.array([1, 1])),
             "b": nir.NIRGraph(
                 nodes={
                     "a": nir.Input(i),
@@ -172,7 +172,12 @@ def test_threshold():
 def test_flatten():
     ir = nir.NIRGraph.from_list(
         nir.Input(shape=np.array([2, 3])),
-        nir.Flatten(),
+        nir.Flatten(
+            start_dim=0,
+            end_dim=0,
+            input_shape=np.array([2, 3]),
+            output_shape=np.array([6]),
+        ),
         nir.Output(shape=np.array([6])),
     )
     factory_test_graph(ir)


### PR DESCRIPTION
we want to have `input_shape` and `output_shape` properties on all NIR nodes. 

in many cases, these shapes can be easily computed from the node itself. if this is possible for a node, this is done in the `__post_init__` method.

if it's not possible to infer the input and output shape from the node directly, then the two fields `input_shape` and `output_shape` are required when creating the node. if these are not passed into the node's constructor, an error is thrown.

**design decisions to be made**
- do we want to enforce input shapes and output shapes? i.e. throw if they are not given? (currently only the case for `Flatten`)
  - alternative: we can allow uninferrable input/output shapes in a node, and then infer them when a NIR Graph is constructed (this allows us to infer the `Flatten` I/O shapes based on its pre- and post-nodes)
- how to implement `input_shape` and `output_shape` for every node? for now I went with option ii) - up for debate
  1. as optional in NIRNode → inherited by all nodes. fails bc they become the first two arguments for all nodes
  2. add input_shape and output_shape into every NIRNode subclass. _(implemented here)_
  3. as optional in NIRNode, and make all nodes `@dataclass(kw_only=True)`. works, but: we always have to initialize everything with keywords (no shortcut as in `ir.Threshold(0.5)`, must be `ir.Threshold(threshold=0.5)`.
  4. make the input_shape and output_shape @properties. this becomes tricky when for nodes where the shapes are not easily inferred from its given data (i.e., `Flatten`).

I'd love some feedback on these two questions. thanks!