### PR TITLE
Specify spatial shapes in convolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you use NIR in your work, please cite the [following Zenodo reference](https:
   month        = jul,
   year         = 2023,
   publisher    = {Zenodo},
-  version      = {0.0.1},
+  version      = {0.2},
   doi          = {10.5281/zenodo.8105042},
   url          = {https://doi.org/10.5281/zenodo.8105042}
 }

--- a/docs/source/about.md
+++ b/docs/source/about.md
@@ -37,7 +37,7 @@ If you use NIR in your work, please cite the [following Zenodo reference](https:
   month        = jul,
   year         = 2023,
   publisher    = {Zenodo},
-  version      = {0.0.1},
+  version      = {0.2},
   doi          = {10.5281/zenodo.8105042},
   url          = {https://doi.org/10.5281/zenodo.8105042}
 }

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -219,7 +219,8 @@ class NIRGraph(NIRNode):
         of nodes in the graph as needed. Assumes that the input_type of the graph is set. Moves
         from the input nodes to the output nodes. Raises ValueError if types are inconsistent.
 
-        Assumes that all input types are of form: {'input': ...} and all output types are of form: {'output': ...}.
+        Assumes that all input types are of form: {'input': ...} and all output types are of form:
+        {'output': ...}.
 
         Currently only supports the inference of output types for Conv1d and Conv2d nodes.
         Does not support nested NIR graphs.
@@ -247,7 +248,7 @@ class NIRGraph(NIRNode):
             ])
             if undef_post_input_type:
                 # define post input_type to be the same as pre output_type
-                print(f'[warning] {post_key}.input_type undefined -> set to {pre_key}.output_type')
+                print(f'[warning] {post_key}.input_type undefined, set to {pre_key}.output_type')
                 post_node.input_type = {
                     k.replace('output', 'input'): v for k, v in pre_node.output_type.items()
                 }
@@ -371,7 +372,7 @@ class Conv1d(NIRNode):
 
     def __post_init__(self):
         if isinstance(self.padding, str) and self.padding not in ["same", "valid"]:
-            raise ValueError(f"padding must be 'same', 'valid', or an integer, not {self.padding}")
+            raise ValueError(f"padding must be 'same', 'valid', or int, not {self.padding}")
         if self.input_shape is None:
             # leave input and output types undefined
             self.input_type = {"input": None}
@@ -427,7 +428,7 @@ class Conv2d(NIRNode):
 
     def __post_init__(self):
         if isinstance(self.padding, str) and self.padding not in ["same", "valid"]:
-            raise ValueError(f"padding must be 'same', 'valid', or an integer, not {self.padding}")
+            raise ValueError(f"padding must be 'same', 'valid', or int, not {self.padding}")
         if isinstance(self.padding, int):
             self.padding = (self.padding, self.padding)
         if isinstance(self.stride, int):

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -21,6 +21,8 @@ def _parse_shape_argument(x: Types, key: str):
         return {key: np.array(x)}
     elif isinstance(x, dict):
         return x
+    elif x is None:
+        return {key: None}
 
 
 def _calculate_conv_output(
@@ -47,15 +49,15 @@ def _calculate_conv_output(
     :return: output shape
     :rtype: typing.Sequence[int]
     """
-    if isinstance(input_shape, int):
+    if isinstance(input_shape, (int, np.integer)):
         ndim = 1
     else:
         ndim = len(input_shape)
-    if padding == 'valid':
+    if isinstance(padding, str) and padding == 'valid':
         padding = [0] * ndim
     shapes = []
     for i in range(ndim):
-        if padding == 'same':
+        if isinstance(padding, str) and padding == 'same':
             shape = input_shape[i]
         else:
             shape = np.floor(
@@ -78,7 +80,7 @@ def _index_tuple(
     """If the input is a tuple/array, index it. Otherwise, return it as-is."""
     if isinstance(tuple, np.ndarray) or isinstance(tuple, Sequence):
         return tuple[index]
-    elif isinstance(tuple, int):
+    elif isinstance(tuple, (int, np.integer)):
         return np.array([tuple])
     else:
         raise TypeError(f"tuple must be int or np.ndarray, not {type(tuple)}")
@@ -174,6 +176,135 @@ class NIRGraph(NIRNode):
         self.output_type = {
             node_key: self.nodes[node_key].output_type for node_key in output_node_keys
         }
+    
+    def _check_types(self):
+        """Check that all nodes in the graph have input and output types. Will raise ValueError
+        if any node has no input or output type, or if the types are inconsistent."""
+        for edge in self.edges:
+            pre_node = self.nodes[edge[0]]
+            post_node = self.nodes[edge[1]]
+
+            # make sure all types are defined
+            undef_out_type = pre_node.output_type is None or any(
+                v is None for v in pre_node.output_type.values()
+            )
+            if undef_out_type:
+                raise ValueError(f'pre node {edge[0]} has no output type')
+            undef_in_type = post_node.input_type is None or any(
+                v is None for v in post_node.input_type.values()
+            )
+            if undef_in_type:
+                raise ValueError(f'post node {edge[1]} has no input type')
+
+            # make sure the length of types is equal
+            if len(pre_node.output_type) != len(post_node.input_type):
+                pre_repr = f'len({edge[0]}.output)={len(pre_node.output_type)}'
+                post_repr = f'len({edge[1]}.input)={len(post_node.input_type)}'
+                raise ValueError(f'type length mismatch: {pre_repr} -> {post_repr}')
+
+            # make sure the type values match up
+            if len(pre_node.output_type.keys()) == 1:
+                post_input_type = list(post_node.input_type.values())[0]
+                pre_output_type = list(pre_node.output_type.values())[0]
+                if not np.array_equal(post_input_type, pre_output_type):
+                    pre_repr = f'{edge[0]}.output: {pre_output_type}'
+                    post_repr = f'{edge[1]}.input: {post_input_type}'
+                    raise ValueError(f'type mismatch: {pre_repr} -> {post_repr}')
+            else:
+                raise NotImplementedError('multiple input/output types not supported yet')
+        return True
+    
+    def _forward_type_inference(self, debug=True):
+        """Infer the types of all nodes in this graph. Will modify the input_type and output_type
+        of nodes in the graph as needed. Assumes that the input_type of the graph is set. Moves
+        from the input nodes to the output nodes. Raises ValueError if types are inconsistent.
+
+        Assumes that all input types are of form: {'input': ...} and all output types are of form: {'output': ...}.
+
+        Currently only supports the inference of output types for Conv1d and Conv2d nodes.
+        Does not support nested NIR graphs.
+        """
+        ready = [e for e in self.edges if e[0] in self.inputs.keys()]
+        seen = set([e[0] for e in ready])
+        while len(ready) > 0:
+            pre_key, post_key = ready.pop()
+            pre_node = self.nodes[pre_key]
+            post_node = self.nodes[post_key]
+            
+            if isinstance(pre_node, NIRGraph) or isinstance(post_node, NIRGraph):
+                raise NotImplementedError('type inference on nested NIR graphs not supported yet')
+            
+            # check if post input_type needs to be defined
+            undef_post_input_type = post_node.input_type is None or any(
+                v is None for v in post_node.input_type.values()
+            )
+            type_mismatch = any([
+                len(post_node.input_type) != len(pre_node.output_type),
+                not np.array_equal(
+                    np.array(list(pre_node.output_type.values())), 
+                    np.array(list(post_node.input_type.values()))
+                )
+            ])
+            if undef_post_input_type:
+                # define post input_type to be the same as pre output_type
+                print(f'[warning] {post_key}.input_type undefined -> set to {pre_key}.output_type')
+                post_node.input_type = {
+                    k.replace('output', 'input'): v for k, v in pre_node.output_type.items()
+                }
+            elif type_mismatch:
+                # set post input_type to be the same as pre output_type
+                pre_repr = f'{pre_key}.output: {np.array(list(pre_node.output_type.values()))}'
+                post_repr = f'{post_key}.input: {np.array(list(post_node.input_type.values()))}'
+                print(f'[warning] overwriting {post_repr} with {pre_repr}')
+                post_node.input_type = {
+                    k.replace('output', 'input'): v for k, v in pre_node.output_type.items()
+                }
+
+            # check if post output_type needs to be defined
+            undef_post_output_type = post_node.output_type is None or any(
+                v is None for v in post_node.output_type.values()
+            )
+            if undef_post_output_type:
+                # define post output_type
+                if isinstance(post_node, Conv1d) or isinstance(post_node, Conv2d):
+                    if isinstance(post_node, Conv1d):
+                        post_node.input_shape = post_node.input_type['input'][1]
+                    else:
+                        post_node.input_shape = tuple(post_node.input_type['input'][1:])
+                    output_shape = _calculate_conv_output(
+                        post_node.input_shape,
+                        post_node.padding,
+                        post_node.dilation,
+                        post_node.weight.shape[2],
+                        post_node.stride,
+                    )
+                    output_type = np.array([post_node.weight.shape[0], *output_shape])
+                    post_node.output_type = {"output": output_type}
+            
+            seen.add(post_key)
+            ready += [e for e in self.edges if e[0] == post_key and e[1] not in seen]
+
+    def infer_types(self):
+        """Infer the shapes of all nodes in this graph. Will modify the input_type and
+        output_type of all nodes in the graph.
+        
+        Assumes that either the input type or the output type of the graph is set.
+        Assumes that if A->B, then A.output_type.values() = B.input_type.values()
+        """
+        undef_input_type = self.input_type is None or any(
+            v is None for v in self.input_type.values()
+        )
+        undef_output_type = self.output_type is None or any(
+            v is None for v in self.output_type.values()
+        )
+        if not undef_input_type:
+            # forward-mode type inferring
+            self._forward_type_inference()
+        elif not undef_output_type:
+            # backward-mode type inferring
+            raise NotImplementedError('backward-mode type inference not implemented yet')
+        else:
+            raise ValueError("Either input_type or output_type must be set")
 
 
 @dataclass(eq=False)

--- a/nir/read.py
+++ b/nir/read.py
@@ -12,6 +12,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
         return nir.Affine(weight=node["weight"][()], bias=node["bias"][()])
     elif node["type"][()] == b"Conv1d":
         return nir.Conv1d(
+            input_shape=node["input_shape"][()],
             weight=node["weight"][()],
             stride=node["stride"][()],
             padding=node["padding"][()],
@@ -21,6 +22,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
         )
     elif node["type"][()] == b"Conv2d":
         return nir.Conv2d(
+            input_shape=node["input_shape"][()],
             weight=node["weight"][()],
             stride=node["stride"][()],
             padding=node["padding"][()],

--- a/nir/write.py
+++ b/nir/write.py
@@ -17,6 +17,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
     elif isinstance(node, nir.Conv1d):
         return {
             "type": "Conv1d",
+            "input_shape": node.input_shape,
             "weight": node.weight,
             "stride": node.stride,
             "padding": node.padding,
@@ -27,6 +28,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
     elif isinstance(node, nir.Conv2d):
         return {
             "type": "Conv2d",
+            "input_shape": node.input_shape,
             "weight": node.weight,
             "stride": node.stride,
             "padding": node.padding,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,6 +7,29 @@ def mock_linear(*shape):
     return nir.Linear(weight=np.random.randn(*shape).T)
 
 
+def mock_conv(input_shape, weights):
+    if len(weights) == 4:
+        return nir.Conv2d(
+            input_shape=input_shape,
+            weight=np.random.randn(*weights),
+            bias=np.random.randn(weights[0]),
+            stride=1,
+            padding=0,
+            dilation=1,
+            groups=1,
+        )
+    else:
+        return nir.Conv1d(
+            input_shape=input_shape,
+            weight=np.random.randn(*weights),
+            bias=np.random.randn(weights[0]),
+            stride=1,
+            padding=0,
+            dilation=1,
+            groups=1,
+        )
+
+
 def mock_affine(*shape):
     return nir.Affine(weight=np.random.randn(*shape).T, bias=np.random.randn(shape[1]))
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -327,3 +327,108 @@ def test_inputs_outputs_properties():
     assert ir.nodes["in2"] in ir2.nodes["inner"].inputs.values()
     assert ir.nodes["out1"] in ir2.nodes["inner"].outputs.values()
     assert ir.nodes["out2"] in ir2.nodes["inner"].outputs.values()
+
+
+def test_conv_type_inference():
+    graphs = {
+        'undef graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64, 64])),
+            'conv': nir.Conv2d(
+                input_shape=(64, 64),
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=None)
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'incorrect graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64, 64])),
+            'conv': nir.Conv2d(
+                input_shape=(64, 64),
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=np.array([1, 61, 1]))
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'undef conv.input': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64, 64])),
+            'conv': nir.Conv2d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=np.array([1, 61, 61]))
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'undef conv.input and graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64, 64])),
+            'conv': nir.Conv2d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=None)
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'Conv1d undef graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64])),
+            'conv': nir.Conv1d(
+                input_shape=64,
+                weight=np.zeros((1, 1, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=None)
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'Conv1d incorrect graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64])),
+            'conv': nir.Conv1d(
+                input_shape=64,
+                weight=np.zeros((1, 1, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=np.array([1, 3]))
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+
+        'Conv1d undef conv.input and graph output': nir.NIRGraph(nodes={
+            'input': nir.Input(input_type=np.array([1, 64])),
+            'conv': nir.Conv1d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None
+            ),
+            'output': nir.Output(output_type=None)
+        }, edges=[('input', 'conv'), ('conv', 'output')]),
+    }
+    for name, graph in graphs.items():
+        graph.infer_types()
+        assert graph._check_types(), f'type inference failed for: {name}'

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -98,6 +98,38 @@ def test_delay():
     assert ir.edges == [("in", "d"), ("d", "out")]
 
 
+def test_conv1d():
+    w = np.random.randn(2, 1, 3)
+    a = nir.Conv1d(
+        input_shape=100,
+        weight=w,
+        stride=2,
+        dilation=1,
+        groups=1,
+        padding=1,
+        bias=np.ndarray([1]),
+    )
+    assert np.allclose(a.weight, w)
+    assert np.allclose(a.input_shape, 100)
+    assert np.allclose(a.output_type["output"], np.array([2, 50]))
+
+
+def test_conv2d():
+    w = np.random.randn(3, 1, 3, 3)
+    a = nir.Conv2d(
+        input_shape=(100, 100),
+        weight=w,
+        padding=(1, 1),
+        stride=(1, 2),
+        dilation=(1, 1),
+        groups=(1, 1),
+        bias=np.ndarray([1]),
+    )
+    assert np.allclose(a.weight, w)
+    assert np.allclose(a.input_shape, np.array([100, 100]))
+    assert np.allclose(a.output_type["output"], np.array([3, 100, 50]))
+
+
 def test_cuba_lif():
     a = np.random.randn(10, 10)
     lif = nir.CubaLIF(tau_mem=a, tau_syn=a, r=a, v_leak=a, v_threshold=a)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -72,7 +72,7 @@ def test_conv1d():
     factory_test_graph(ir)
 
 
-def test_conv1d():
+def test_conv1d_2():
     ir = nir.NIRGraph.from_list(
         mock_conv((100, 100), (1, 2, 3, 3)),
     )

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -3,7 +3,7 @@ import tempfile
 import numpy as np
 
 import nir
-from tests import mock_affine
+from tests import mock_affine, mock_conv
 
 
 def assert_equivalence(ir: nir.NIRGraph, ir2: nir.NIRGraph):
@@ -61,6 +61,22 @@ def test_nested():
         edges=[("a", "b"), ("b", "a")],
     )
     factory_test_graph(nested)
+
+
+def test_conv1d():
+    ir = nir.NIRGraph.from_list(
+        mock_affine(2, 100),
+        mock_conv(100, (1, 2, 3)),
+        mock_affine(100, 2),
+    )
+    factory_test_graph(ir)
+
+
+def test_conv1d():
+    ir = nir.NIRGraph.from_list(
+        mock_conv((100, 100), (1, 2, 3, 3)),
+    )
+    factory_test_graph(ir)
 
 
 def test_integrator():


### PR DESCRIPTION
As @matjobst pointed out, the convolutions incorrectly uses the weights to infer the spatial shape of the convolutions.
Second, they do not correctly serialize and deserialize.

This PR fixes the shapes of the convolutions to address both. However, it means that we are *forcing* the convolutions to be of a certain shape. I believe you, @sheiksadique, argued against this, so I would be curious to hear your opinion on this.