### PR TITLE
enforce the validity of NIR graphs on creation

### DIFF
--- a/nir/ir.py
+++ b/nir/ir.py
@@ -176,6 +176,13 @@ class NIRGraph(NIRNode):
         self.output_type = {
             node_key: self.nodes[node_key].output_type for node_key in output_node_keys
         }
+        # check that all nodes have consistent and defined input and output types
+        try:
+            self._check_types()
+        except ValueError as e:
+            print(f'[warning] {e}')
+            self.infer_types()
+            self._check_types()
     
     def _check_types(self):
         """Check that all nodes in the graph have input and output types. Will raise ValueError

--- a/nir/read.py
+++ b/nir/read.py
@@ -88,10 +88,16 @@ def read_node(node: typing.Any) -> nir.NIRNode:
         raise ValueError(f"Unknown unit type: {node['type'][()]}")
 
 
-def read(filename: typing.Union[str, pathlib.Path]) -> nir.NIRGraph:
-    """Load a NIR from a HDF/conn5 file."""
+def read(filename: typing.Union[str, pathlib.Path], strict=True) -> nir.NIRGraph:
+    """Load a NIR from a HDF/conn5 file. If strict, only load valid graphs."""
     with h5py.File(filename, "r") as f:
-        return read_node(f["node"])
+        graph: nir.NIRGraph = read_node(f["node"])
+        if not graph.is_valid():
+            print('[WARNING] graph is invalid, attempting nir.NIRGraph.infer_types()')
+            graph = graph.infer_types()
+            if not graph.is_valid() and strict:
+                raise ValueError("Invalid graph, could not read.")
+        return graph
 
 
 def read_version(filename: typing.Union[str, pathlib.Path]) -> str:

--- a/nir/write.py
+++ b/nir/write.py
@@ -107,8 +107,11 @@ def _convert_node(node: nir.NIRNode) -> dict:
         raise ValueError(f"Unknown node type: {node}")
 
 
-def write(filename: typing.Union[str, pathlib.Path], graph: nir.NIRNode) -> None:
-    """Write a NIR to a HDF5 file."""
+def write(filename: typing.Union[str, pathlib.Path], graph: nir.NIRNode, strict=True) -> None:
+    """Write a NIR to a HDF5 file. If strict, only allow valid graphs to be written."""
+
+    if not graph.is_valid() and strict:
+        raise ValueError("Cannot write an invalid graph. See NIRGraph.is_valid().")
 
     def write_recursive(group: h5py.Group, node: dict) -> None:
         for k, v in node.items():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -431,4 +431,4 @@ def test_conv_type_inference():
     }
     for name, graph in graphs.items():
         graph.infer_types()
-        assert graph._check_types(), f'type inference failed for: {name}'
+        assert graph.is_valid(), f'type inference failed for: {name}'


### PR DESCRIPTION
PR #59 introduces code to check the consistency and "defined-ness" of input and output types across a NIR graph (also pointed out in #4). This is currently not enforced. 

However, NIR, as an intermediate representation, would do well to enforce the correctness of all created NIR graphs. Otherwise, we end up with potentially many invalid NIR graphs that will effectively be un-parseable. 

This PR enforces the validity of NIR graphs, as defined by the `NIRGraph._check_types()` method. If the graph types are undefined or inconsistent, a warning is printed and an attempt is made to infer them with `NIRGraph.infer_types()`. If this fails, an error is thrown. 

TODO:
- fix tests

_Note: this can also be merged only after our paper deadline._