### PR TITLE
Bug fixes: nir.Output type inference & CubaLIF.w_in read/write

### DIFF
--- a/nir/ir.py
+++ b/nir/ir.py
@@ -261,6 +261,12 @@ class NIRGraph(NIRNode):
                     k.replace('output', 'input'): v for k, v in pre_node.output_type.items()
                 }
 
+            # make sure that output nodes have output_type = input_type
+            if isinstance(post_node, Output):
+                post_node.output_type = {
+                    k.replace('input', 'output'): v for k, v in post_node.input_type.items()
+                }
+
             # check if post output_type needs to be defined
             undef_post_output_type = post_node.output_type is None or any(
                 v is None for v in post_node.output_type.values()

--- a/nir/ir.py
+++ b/nir/ir.py
@@ -285,6 +285,9 @@ class NIRGraph(NIRNode):
             seen.add(post_key)
             ready += [e for e in self.edges if e[0] == post_key and e[1] not in seen]
 
+            self.nodes[pre_key] = pre_node
+            self.nodes[post_key] = post_node
+
     def infer_types(self):
         """Infer the shapes of all nodes in this graph. Will modify the input_type and
         output_type of all nodes in the graph.

--- a/nir/read.py
+++ b/nir/read.py
@@ -72,6 +72,7 @@ def read_node(node: typing.Any) -> nir.NIRNode:
             r=node["r"][()],
             v_leak=node["v_leak"][()],
             v_threshold=node["v_threshold"][()],
+            w_in=node["w_in"][()],
         )
     elif node["type"][()] == b"NIRGraph":
         return nir.NIRGraph(

--- a/nir/write.py
+++ b/nir/write.py
@@ -87,6 +87,7 @@ def _convert_node(node: nir.NIRNode) -> dict:
             "r": node.r,
             "v_leak": node.v_leak,
             "v_threshold": node.v_threshold,
+            "w_in": node.w_in,
         }
     elif isinstance(node, nir.NIRGraph):
         return {


### PR DESCRIPTION
~Right now, the type inference goes through but it doesn't actually change the NIR graph. This PR fixes that.~

Update: this PR fixes a weird edge case where the input_type of a `nir.Output` node is inferred. This currently fails because it will not update the output_type for the `nir.Output` node and this is used when writing the graph to a file. (hence, when writing to a file and reading again, the shape inference is essentially discarded). 

Update update: I've also added an urgent fix that adds `w_in` to the read and write method of the `CubaLIF` node. This should have always been there..