### PR TITLE
Remove docs and paper data/code from release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+prune paper
+prune docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ testpaths = ["tests"]
 [tool.setuptools_scm] 
 
 [tool.setuptools.packages]
-find = {} 
+find={include = ["nir*"]}
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
This is a fix for #98 
There is no way to remove stuff from the source distribution using a config inside pyproject.toml as long as we are using setuptools_scm (see https://github.com/pypa/setuptools_scm/issues/190). As soon as setuptools_scm is used, all data which is under version control is added. The solution proposed by the authors of setuptools_scm is to add a MANIFEST.in.
In the MANIFEST.in, I remove the docs and the paper folders as these should not be required for a source distribution via pypi.
Additrionally I added `find={include = ["nir*"]}` in the pyproject.toml which will cause only the nir folder to be added to the wheel (the other files should not be required).
I tested it locally and it seems to work. But please also check it, @Jegp .
Resulting sizes are ~19 kB for the wheel and 25 kB for the source.