### PR TITLE
update snntorch example

### DIFF
--- a/docs/source/examples/snntorch/nir-conversion.ipynb
+++ b/docs/source/examples/snntorch/nir-conversion.ipynb
@@ -6,13 +6,83 @@
    "source": [
     "# snnTorch\n",
     "\n",
-    "... coming soon"
+    "snnTorch is a deep learning simulator for spiking neural networks, built on PyTorch."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": []
+   "source": [
+    "## Import a NIR graph to snTorch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import snntorch as snn\n",
+    "import torch\n",
+    "\n",
+    "import nir\n",
+    "\n",
+    "# Create a NIR Network\n",
+    "affine_weights = torch.tensor([[1.0, 2.0], [3.0, 4.0]])\n",
+    "affine_bias = torch.tensor([1.0, 2.0])\n",
+    "li_tau = torch.tensor([0.9, 0.8])\n",
+    "li_r = torch.tensor([1.0, 1.0])\n",
+    "li_v_leak = torch.tensor([0.0, 0.0])\n",
+    "nir_network = nir.NIRGraph.from_list(nir.Affine(affine_weights, affine_bias), nir.LI(li_tau, li_r, li_v_leak))\n",
+    "\n",
+    "# Import to snnTorch\n",
+    "snntorch_network = snn.import_from_nir(nir_network)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Export a NIR graph from snnTorch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import snntorch as snn\n",
+    "import torch\n",
+    "\n",
+    "lif1 = snn.Leaky(beta=0.9, init_hidden=True)\n",
+    "lif2 = snn.Leaky(beta=0.9, init_hidden=True, output=True)\n",
+    "\n",
+    "# Create a network\n",
+    "snntorch_network = torch.nn.Sequential(\n",
+    "    torch.nn.Flatten(),\n",
+    "    torch.nn.Linear(784, 500),\n",
+    "    lif1,\n",
+    "    torch.nn.Linear(500, 10),\n",
+    "    lif2\n",
+    ")\n",
+    "\n",
+    "sample_data = torch.randn(1, 784)\n",
+    "\n",
+    "# Export to nir\n",
+    "nir_model = snn.export_to_nir(snntorch_network, sample_data)\n",
+    "\n",
+    "# Save to file\n",
+    "nir.write(\"nir_model.nir\", nir_model)"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
ipynb file has been added. 

It follows the same syntax as the Norse tutorial, though an error is thrown at the following line:

```
# Save to file
nir.write("nir_model.nir", nir_model)
```

Note: I also had to pass in `sample_data` into the network to make it usable, which the Norse example does not have.