### PR TITLE
Fix S2 SCNN notebook

### DIFF
--- a/paper/02_cnn/s2_apply.ipynb
+++ b/paper/02_cnn/s2_apply.ipynb
@@ -324,7 +324,7 @@
     "outp = None\n",
     "for pop in net.populations:\n",
     "    if pop.name == \"1\":\n",
-    "        pop.record = [\"v\", \"spikes\"]\n",
+    "        pop.record = [\"spikes\"]\n",
     "        outp = [pop]\n",
     "        break\n",
     "print(\"outp\", outp[0].name, outp[0].record)"


### PR DESCRIPTION
At the end of the S2 SCNN paper notebook, the activations of the first IF layer could not be extracted due to out of memory error in SpiNNaker2. This was caused by not only extracting the spikes, but also storing the voltages, even though they were not required.
This just disables storage of the voltages.