### PR TITLE
Add metadata to missing nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.0.277
+  rev: v0.6.0
   hooks:
     - id: ruff
 

--- a/nir/ir/conv.py
+++ b/nir/ir/conv.py
@@ -106,6 +106,7 @@ class Conv2d(NIRNode):
     dilation: Union[int, Tuple[int, int]]  # Dilation
     groups: int  # Groups
     bias: np.ndarray  # Bias C_out
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if isinstance(self.padding, str) and self.padding not in ["same", "valid"]:

--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -452,6 +452,7 @@ class Input(NIRNode):
     # Shape of incoming data (overrrides input_type from
     # NIRNode to allow for non-keyword (positional) initialization)
     input_type: Types
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         self.input_type = parse_shape_argument(self.input_type, "input")
@@ -479,6 +480,7 @@ class Output(NIRNode):
     # Type of incoming data (overrrides input_type from
     # NIRNode to allow for non-keyword (positional) initialization)
     output_type: Types
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         self.output_type = parse_shape_argument(self.output_type, "output")

--- a/nir/ir/linear.py
+++ b/nir/ir/linear.py
@@ -46,6 +46,7 @@ class Linear(NIRNode):
     """
 
     weight: np.ndarray  # Weight term
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         assert len(self.weight.shape) >= 2, "Weight must be at least 2D"
@@ -69,6 +70,7 @@ class Scale(NIRNode):
     """
 
     scale: np.ndarray  # Scaling factor
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         self.input_type = {"input": np.array(self.scale.shape)}

--- a/nir/ir/pooling.py
+++ b/nir/ir/pooling.py
@@ -29,6 +29,7 @@ class AvgPool2d(NIRNode):
     kernel_size: np.ndarray  # (Height, Width)
     stride: np.ndarray  # (Height, width)
     padding: np.ndarray  # (Height, width)
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         self.input_type = {"input": None}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,3 +49,5 @@ find={include = ["nir*"]}
 line-length = 100
 lint.per-file-ignores = {"docs/conf.py" = ["E402"]}
 exclude  = ["paper/"]
+extend-exclude = ["*.ipynb"]
+


### PR DESCRIPTION
In the previous version, not all nodes had the `metadata` attribute.
Metadata was now added to all missing nodes.

Also the tests for checking the metadata export/import was updated to consider all nodes in the graph.