### PR TITLE
README typo fixed in 03_rnn

### DIFF
--- a/paper/03_rnn/README.md
+++ b/paper/03_rnn/README.md
@@ -45,7 +45,7 @@ Please use as many graphs as your platform supports. The more data in the paper,
 ### Already available examples
 
 The following examples can be used to get started with NIR export/import:
- - `snntorch_apply.ipynb` to train a SRNN in snnTorch with optimized hyperparameters
+ - `Braille_training_snntorch.ipynb` to train a SRNN in snnTorch with optimized hyperparameters
  - `lava_apply.py` to load a graph into Lava and perform inference
  - `nengo_apply.ipynb` to load a graph into Nengo and perform inference
  - `norse_apply.ipynb` to load a graph into Norse, make some analysis and perform inference
@@ -58,4 +58,4 @@ The following examples can be used to get started with NIR export/import:
 
 ## *Additional information for training*
 
-To train the Braille reading model in snnTorch, use the above listed `braille_training_snntorch.ipynb` notebook. By setting the `reset_mechanism`, `reset_delay` and `parameters_filename` variables, the different models (and corresponding hyperparameters) can be selected. The variable `use_bias` allows to specify if bias can be used or not depending on the target platform. At the very beginning of the notebook, the `store_weights` variable can be set as True or False according to what is needed. A cell for GPU usage is also present.
+To train the Braille reading model in snnTorch, use the above listed `Braille_training_snntorch.ipynb` notebook. By setting the `reset_mechanism`, `reset_delay` and `parameters_filename` variables, the different models (and corresponding hyperparameters) can be selected. The variable `use_bias` allows to specify if bias can be used or not depending on the target platform. At the very beginning of the notebook, the `store_weights` variable can be set as True or False according to what is needed. A cell for GPU usage is also present.


### PR DESCRIPTION
In the README for the RNN experiments, there was a mismatch between files and description.