### PR TITLE
Fix most notebook dependency issues

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,13 @@ sphinx_external_toc
 sphinxcontrib-mermaid
 astroid~=2.15 # https://github.com/readthedocs/sphinx-autoapi/issues/407
 sphinx-autoapi
+nir
+matplotlib
+lava
+nengo
+norse
+rockpool
+sinabs
+snntorch
+spyx
+jax


### PR DESCRIPTION
I updated the docs/requirements.txt file, I assume that should help with the dependency issues in the notebooks. Spinnaker2 I couldn't find in pip so that isn't solved here.

There seem to be some other errors in the notebooks as well. Some are just because of incorrect variables (e.g. 'input_type' instead of 'output_type' in the lava example). But also, the way in which the NIRGraph in e.g. the lava example is created doesn't work, seemingly because a dict of nodes is expected instead of a list. Should a different issue be made for these problems?