### PR TITLE
Throw AttributeError for NIRNode constructor

### DIFF
--- a/nir/ir/node.py
+++ b/nir/ir/node.py
@@ -1,9 +1,10 @@
+from abc import ABC
 from dataclasses import asdict, dataclass
 from typing import Any, Dict
 
 
 @dataclass(eq=False)
-class NIRNode:
+class NIRNode(ABC):
     """Base superclass of Neural Intermediate Representation Unit (NIR).
 
     All NIR primitives inherit from this class, but NIRNodes should never be
@@ -15,6 +16,9 @@ class NIRNode:
     # input_type: Dict[str, np.ndarray] = field(init=False, kw_only=True)
     # output_type: Dict[str, np.ndarray] = field(init=False, kw_only=True)
     # metadata: Dict[str, Any] = field(init=True, default_factory=dict)
+
+    def __init__(self) -> None:
+        raise AttributeError("NIRNode does not have a default constructor.")
 
     def __eq__(self, other):
         return self is other

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -582,3 +582,13 @@ def test_conv_type_inference():
             raise AssertionError(f"type check failed for: {name}")
         graph.infer_types()
         assert graph._check_types(), f"type inference failed for: {name}"
+
+
+def test_node():
+    try:
+        node = nir.ir.NIRNode()
+        assert (
+            node is None
+        ), f"test failed, we should not be able to construct an NIRNode: {node}"
+    except AttributeError:
+        pass


### PR DESCRIPTION
# Fix for https://github.com/neuromorphs/NIR/issues/120

- Added inheritance to `NIRNode` from [abc](https://docs.python.org/3/library/abc.html). This might be too much, but given that the stated documentation for `NIRNode` is that it is a "base superclass" and that "NIRNodes should never be instantiated", indicating this property through inheritance in a Pythonic way.
- Throws `AttributeError` on call `NIRNode.__init__` as a proposed fix for [Issue 120](https://github.com/neuromorphs/NIR/issues/120).
- Added a simple test `test_node` which checks if a `NIRNode` class can be constructed. All tests pass, it seems.

# Potential Downsides

- Inheriting from `abc.ABC` might have some unintended consequences in behavior that I am not familiar with, this change I think can be discarded if there are any unintended problems that arise.
- This solution might be a little clumsy and lead to unclear API usage. For example, if a user introspects at runtime on the methods of `NIRNode`, they will find that `__init__` is in fact defined. However, the exception raised here is one used to indicate that there is in fact no `__init__` method. One potential alternative is to raise [`TypeError`](https://docs.python.org/3/library/exceptions.html#TypeError), which "may be raised by user code to indicate that an attempted operation on an object is not supported, and is not meant to be".

P.S. This is my first attempted contribution to an open-source library ❤️