### PR TITLE
pre-commit hook: bump docformatter to fix error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       args: ["--profile", "black", "--filter-files"]
 
 - repo: https://github.com/myint/docformatter
-  rev: v1.7.5
+  rev: v1.7.7
   hooks:
     - id: docformatter
       args: [--in-place, --black, --wrap-summaries=88, --wrap-descriptions=88]


### PR DESCRIPTION
Without this, I get the following error when committing:
```
==> File /home/vscode/.cache/pre-commit/repo6ita8v9e/.pre-commit-hooks.yaml
==> At Hook(id='docformatter-venv')
==> At key: language
=====> Expected one of conda, coursier, dart, docker, docker_image, dotnet, fail, golang, haskell, julia, lua, node, perl, pygrep, python, r, ruby, rust, script, swift, system but got: 'python_venv'
```

Related: https://github.com/PyCQA/docformatter/pull/287