### PR TITLE
Prevent from_dict from modifying non-local scope

### DIFF
--- a/nir/ir/neuron.py
+++ b/nir/ir/neuron.py
@@ -171,7 +171,7 @@ class IF(NIRNode):
         ), "All parameters must have the same shape"
         self.input_type = {"input": np.array(self.r.shape)}
         self.output_type = {"output": np.array(self.r.shape)}
-    
+
     @classmethod
     def from_dict(cls, kwargs: Dict[str, Any]) -> "IF":
         if "v_reset" not in kwargs:

--- a/nir/ir/node.py
+++ b/nir/ir/node.py
@@ -39,7 +39,7 @@ class NIRNode(ABC):
     @classmethod
     def from_dict(cls, kwargs: Dict[str, Any]) -> "NIRNode":
         assert kwargs["type"] == cls.__name__
-        kwargs = kwargs.copy() # Local scope
+        kwargs = kwargs.copy()  # Local scope
         del kwargs["type"]
 
         return cls(**kwargs)

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -300,10 +300,12 @@ def test_deserialize():
     current_path = os.path.abspath(__file__)
     nir_base = os.path.dirname(os.path.dirname(current_path))
 
-    nir_files = ["paper/03_rnn/braille_noDelay_noBias_subtract.nir",
+    nir_files = [
+        "paper/03_rnn/braille_noDelay_noBias_subtract.nir",
         "paper/03_rnn/braille_noDelay_bias_zero.nir",
         "paper/01_lif/lif_norse.nir",
-        "paper/01_lif/debug_spike_representation/two_lif_neurons.nir"]
+        "paper/01_lif/debug_spike_representation/two_lif_neurons.nir",
+    ]
 
     for file in nir_files:
         try:


### PR DESCRIPTION
kwargs here is a pointer, so del would delete it from the parent variable.