### PR TITLE
Enhanced type inference and checking, called from NIRGraph.__init__

### DIFF
--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -55,7 +55,7 @@ class NIRGraph(NIRNode):
 
         # Check that all nodes have input and output types, if requested (default)
         if type_check:
-            self._check_types()
+            self.check_types()
 
         # Call post init to set input_type and output_type
         self.__post_init__()
@@ -192,7 +192,7 @@ class NIRGraph(NIRNode):
         else:
             raise ValueError("Either input_type or output_type must be set")
 
-    def _check_types(self):
+    def check_types(self):
         """Check that all nodes in the graph have input and output types.
 
         Will raise ValueError if any node has no input or output type, or if the types

--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -416,6 +416,14 @@ class NIRGraph(NIRNode):
         source_nodes = {edge[0] for edge in self.edges}
         leaf_nodes = all_node_keys - source_nodes
 
+        if not leaf_nodes:
+            raise ValueError(
+                "Type inference failed: No output nodes found. "
+                "This may be due to a cyclic dependency at the graph's output. "
+                "Please add an `Output` node manually to define an exit point, "
+                "or disable type checking (`type_check=False`)."
+            )
+
         new_nodes: Dict[str, NIRNode] = {}
         new_edges: Edges = []
 

--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -55,6 +55,7 @@ class NIRGraph(NIRNode):
 
         # Check that all nodes have input and output types, if requested (default)
         if type_check:
+            self._forward_type_inference()
             self.check_types()
 
         # Call post init to set input_type and output_type

--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -235,7 +235,7 @@ class NIRGraph(NIRNode):
                 )
         return True
 
-    def _forward_type_inference(self, debug=True):
+    def _forward_type_inference(self):
         """Infer the types of all nodes in this graph. Will modify the input_type and
         output_type of nodes in the graph as needed. Assumes that the input_type of the
         graph is set. Moves from the input nodes to the output nodes. Raises ValueError
@@ -274,9 +274,6 @@ class NIRGraph(NIRNode):
             )
             if undef_post_input_type:
                 # define post input_type to be the same as pre output_type
-                print(
-                    f"[warning] {post_key}.input_type undefined, set to {pre_key}.output_type"
-                )
                 post_node.input_type = {
                     k.replace("output", "input"): v
                     for k, v in pre_node.output_type.items()
@@ -289,11 +286,9 @@ class NIRGraph(NIRNode):
                 post_repr = (
                     f"{post_key}.input: {np.array(list(post_node.input_type.values()))}"
                 )
-                print(f"[warning] overwriting {post_repr} with {pre_repr}")
-                post_node.input_type = {
-                    k.replace("output", "input"): v
-                    for k, v in pre_node.output_type.items()
-                }
+                raise ValueError(
+                    f"Type inference error: type mismatch: {pre_repr} -> {post_repr}"
+                )
 
             # make sure that output nodes have output_type = input_type
             if isinstance(post_node, Output):
@@ -350,7 +345,6 @@ class NIRGraph(NIRNode):
                     post_node.output_type = {"output": output_type}
 
                 elif isinstance(post_node, Flatten):
-                    print("updateing flatten output")
                     post_node.output_type = {
                         "output": calc_flatten_output(
                             post_node.input_type["input"],

--- a/nir/ir/graph.py
+++ b/nir/ir/graph.py
@@ -247,6 +247,9 @@ class NIRGraph(NIRNode):
         Currently only supports the inference of output types for Conv1d and Conv2d nodes.
         Does not support nested NIR graphs.
         """
+        if not self.nodes or not self.edges:
+            return
+
         # Ensure all graph inputs flow through an Input node
         all_node_keys = set(self.nodes.keys())
         destination_nodes = {edge[1] for edge in self.edges}

--- a/paper/03_rnn/extras/snntorch_debug_nirgraphs.ipynb
+++ b/paper/03_rnn/extras/snntorch_debug_nirgraphs.ipynb
@@ -90,7 +90,7 @@
     }
    ],
    "source": [
-    "ng1._check_types()"
+    "ng1.check_types()"
    ]
   },
   {
@@ -110,7 +110,7 @@
     }
    ],
    "source": [
-    "ng2._check_types()"
+    "ng2.check_types()"
    ]
   },
   {

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -55,7 +55,7 @@ def test_simple():
     assert np.allclose(ir.nodes["a"].bias, a.bias)
     assert np.allclose(ir.nodes["b"].weight, b.weight)
     assert np.allclose(ir.nodes["b"].bias, b.bias)
-    assert ("a", "b") in ir.edges
+    assert sorted([("input_a", "a"), ("a", "b"), ("b", "output_b")]) == sorted(ir.edges)
 
 
 def test_nested():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -295,14 +295,14 @@ def test_graph_from_dict_type_checked():
     with pytest.raises(AssertionError):
         nir.NIRGraph.from_dict({"type": "Input"})
 
-    with pytest.raises(ValueError):
-        nodes = {
-            "input": {"type": "Input", "shape": np.array([2])},
-            "module": {"type": "Linear", "weight": np.random.random((2, 2))},
-            "output": {"type": "Output", "shape": np.array([3])},
-        }
-        kwargs = {"nodes": nodes, "edges": [("input", "module"), ("module", "output")]}
-        nir.NIRGraph.from_dict(kwargs)
+    # with pytest.raises(ValueError):
+    #    nodes = {
+    #        "input": {"type": "Input", "shape": np.array([2])},
+    #        "module": {"type": "Linear", "weight": np.random.random((2, 2))},
+    #        "output": {"type": "Output", "shape": np.array([3])},
+    #    }
+    #    kwargs = {"nodes": nodes, "edges": [("input", "module"), ("module", "output")]}
+    #    nir.NIRGraph.from_dict(kwargs)
 
 
 @pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -68,11 +68,13 @@ def test_nested():
             "input": nir.Input(input_type=np.array([3])),
             "integrator": i,
             "delay": d,
+            "output": nir.Output(output_type=None),
         },
         edges=[
             ("input", "integrator"),
             ("integrator", "delay"),
             ("delay", "integrator"),
+            ("integrator", "output"),
         ],
     )
     ir = nir.NIRGraph(
@@ -88,6 +90,7 @@ def test_nested():
         ("input", "integrator"),
         ("integrator", "delay"),
         ("delay", "integrator"),
+        ("integrator", "output"),
     ]
 
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -406,13 +406,13 @@ def test_sumpool_type_inference():
     }
     for name, graph in graphs.items():
         try:
-            graph._check_types()
+            graph.check_types()
         except Exception:
             pass
         else:
             raise AssertionError(f"type check failed for: {name}")
         graph.infer_types()
-        assert graph._check_types(), f"type inference failed for: {name}"
+        assert graph.check_types(), f"type inference failed for: {name}"
 
 
 @pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
@@ -433,13 +433,13 @@ def test_avgpool_type_inference():
     }
     for name, graph in graphs.items():
         try:
-            graph._check_types()
+            graph.check_types()
         except Exception:
             pass
         else:
             raise AssertionError(f"type check failed for: {name}")
         graph.infer_types()
-        assert graph._check_types(), f"type inference failed for: {name}"
+        assert graph.check_types(), f"type inference failed for: {name}"
 
 
 @pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
@@ -484,13 +484,13 @@ def test_flatten_type_inference():
     }
     for name, graph in graphs.items():
         try:
-            graph._check_types()
+            graph.check_types()
         except Exception:
             pass
         else:
             raise AssertionError(f"type check failed for: {name}")
         graph.infer_types()
-        assert graph._check_types(), f"type inference failed for: {name}"
+        assert graph.check_types(), f"type inference failed for: {name}"
 
 
 @pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
@@ -612,13 +612,13 @@ def test_conv_type_inference():
     for name, graph in graphs.items():
         try:
             # this should raise an exception
-            graph._check_types()
+            graph.check_types()
         except Exception:
             pass
         else:
             raise AssertionError(f"type check failed for: {name}")
         graph.infer_types()
-        assert graph._check_types(), f"type inference failed for: {name}"
+        assert graph.check_types(), f"type inference failed for: {name}"
 
 
 def test_node():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -43,10 +43,19 @@ def test_eq():
 
 def test_simple():
     a = mock_affine(3, 3)
-    ir = nir.NIRGraph(nodes={"a": a}, edges=[("a", "a")])
+    b = mock_affine(3, 3)
+    ir = nir.NIRGraph(
+        nodes={
+            "a": a,
+            "b": b,
+        },
+        edges=[("a", "b")],
+    )
     assert np.allclose(ir.nodes["a"].weight, a.weight)
     assert np.allclose(ir.nodes["a"].bias, a.bias)
-    assert ir.edges == [("a", "a")]
+    assert np.allclose(ir.nodes["b"].weight, b.weight)
+    assert np.allclose(ir.nodes["b"].bias, b.bias)
+    assert ("a", "b") in ir.edges
 
 
 def test_nested():
@@ -56,10 +65,15 @@ def test_nested():
 
     nested = nir.NIRGraph(
         nodes={
+            "input": nir.Input(input_type=np.array([3])),
             "integrator": i,
             "delay": d,
         },
-        edges=[("integrator", "delay"), ("delay", "integrator")],
+        edges=[
+            ("input", "integrator"),
+            ("integrator", "delay"),
+            ("delay", "integrator"),
+        ],
     )
     ir = nir.NIRGraph(
         nodes={"affine": a, "inner": nested},
@@ -70,7 +84,11 @@ def test_nested():
     assert np.allclose(ir.nodes["affine"].bias, a.bias)
     assert np.allclose(ir.nodes["inner"].nodes["integrator"].r, i.r)
     assert np.allclose(ir.nodes["inner"].nodes["delay"].delay, d.delay)
-    assert ir.nodes["inner"].edges == [("integrator", "delay"), ("delay", "integrator")]
+    assert ir.nodes["inner"].edges == [
+        ("input", "integrator"),
+        ("integrator", "delay"),
+        ("delay", "integrator"),
+    ]
 
 
 def test_simple_with_input_output():
@@ -188,9 +206,11 @@ def test_threshold():
 
 def test_linear():
     a = mock_linear(3, 3)
-    ir = nir.NIRGraph(nodes={"a": a}, edges=[("a", "a")])
+    b = mock_linear(3, 3)
+    ir = nir.NIRGraph(nodes={"a": a, "b": b}, edges=[("a", "b")])
     assert np.allclose(ir.nodes["a"].weight, a.weight)
-    assert ir.edges == [("a", "a")]
+    assert np.allclose(ir.nodes["b"].weight, b.weight)
+    assert ("a", "b") in ir.edges
 
 
 def test_flatten():

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -295,14 +295,14 @@ def test_graph_from_dict_type_checked():
     with pytest.raises(AssertionError):
         nir.NIRGraph.from_dict({"type": "Input"})
 
-    # with pytest.raises(ValueError):
-    #    nodes = {
-    #        "input": {"type": "Input", "shape": np.array([2])},
-    #        "module": {"type": "Linear", "weight": np.random.random((2, 2))},
-    #        "output": {"type": "Output", "shape": np.array([3])},
-    #    }
-    #    kwargs = {"nodes": nodes, "edges": [("input", "module"), ("module", "output")]}
-    #    nir.NIRGraph.from_dict(kwargs)
+    with pytest.raises(ValueError):
+        nodes = {
+            "input": {"type": "Input", "shape": np.array([3])},
+            "module": {"type": "Linear", "weight": np.random.random((2, 2))},
+            "output": {"type": "Output", "shape": np.array([3])},
+        }
+        kwargs = {"nodes": nodes, "edges": [("input", "module"), ("module", "output")]}
+        nir.NIRGraph.from_dict(kwargs)
 
 
 @pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
@@ -388,237 +388,178 @@ def test_inputs_outputs_properties():
     assert ir.nodes["out2"] in ir2.nodes["inner"].outputs.values()
 
 
-@pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
 def test_sumpool_type_inference():
-    graphs = {
-        "undef graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "sumpool": nir.SumPool2d(
-                    kernel_size=np.array([2, 2]),
-                    stride=np.array([2, 2]),
-                    padding=np.array([0, 0]),
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "sumpool"), ("sumpool", "output")],
-        ),
-    }
-    for name, graph in graphs.items():
-        try:
-            graph.check_types()
-        except Exception:
-            pass
-        else:
-            raise AssertionError(f"type check failed for: {name}")
-        graph.infer_types()
-        assert graph.check_types(), f"type inference failed for: {name}"
+    graph = nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "sumpool": nir.SumPool2d(
+                kernel_size=np.array([2, 2]),
+                stride=np.array([2, 2]),
+                padding=np.array([0, 0]),
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "sumpool"), ("sumpool", "output")],
+    )
+    assert np.array_equal(graph.output_type["output"], np.array([1, 32, 32]))
+    assert np.array_equal(
+        graph.nodes["output"].input_type["input"], np.array([1, 32, 32])
+    )
+    assert np.array_equal(
+        graph.nodes["output"].output_type["output"], np.array([1, 32, 32])
+    )
 
 
-@pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
 def test_avgpool_type_inference():
-    graphs = {
-        "undef graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "avgpool": nir.AvgPool2d(
-                    kernel_size=np.array([2, 2]),
-                    stride=np.array([2, 2]),
-                    padding=np.array([0, 0]),
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "avgpool"), ("avgpool", "output")],
-        ),
-    }
-    for name, graph in graphs.items():
-        try:
-            graph.check_types()
-        except Exception:
-            pass
-        else:
-            raise AssertionError(f"type check failed for: {name}")
-        graph.infer_types()
-        assert graph.check_types(), f"type inference failed for: {name}"
+    graph = nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "avgpool": nir.AvgPool2d(
+                kernel_size=np.array([2, 2]),
+                stride=np.array([2, 2]),
+                padding=np.array([0, 0]),
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "avgpool"), ("avgpool", "output")],
+    )
+    assert np.array_equal(graph.output_type["output"], np.array([1, 32, 32]))
+    assert np.array_equal(
+        graph.nodes["output"].input_type["input"], np.array([1, 32, 32])
+    )
+    assert np.array_equal(
+        graph.nodes["output"].output_type["output"], np.array([1, 32, 32])
+    )
 
 
-@pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
 def test_flatten_type_inference():
-    graphs = {
-        "undef graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "flatten": nir.Flatten(
-                    start_dim=0, end_dim=0, input_type=np.array([1, 64, 64])
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "flatten"), ("flatten", "output")],
-        ),
-        "incorrect graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "flatten": nir.Flatten(
-                    start_dim=0, end_dim=0, input_type=np.array([1, 64, 64])
-                ),
-                "output": nir.Output(output_type=np.array([1, 61, 1])),
-            },
-            edges=[("input", "flatten"), ("flatten", "output")],
-        ),
-        "undef flatten.input": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "flatten": nir.Flatten(start_dim=0, end_dim=0, input_type=None),
-                "output": nir.Output(output_type=np.array([1, 61, 61])),
-            },
-            edges=[("input", "flatten"), ("flatten", "output")],
-        ),
-        "undef flatten.input and graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "flatten": nir.Flatten(start_dim=0, end_dim=0, input_type=None),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "flatten"), ("flatten", "output")],
-        ),
-    }
-    for name, graph in graphs.items():
-        try:
-            graph.check_types()
-        except Exception:
-            pass
-        else:
-            raise AssertionError(f"type check failed for: {name}")
-        graph.infer_types()
-        assert graph.check_types(), f"type inference failed for: {name}"
+    # TODO: Add assertions
+
+    # undef graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "flatten": nir.Flatten(
+                start_dim=0, end_dim=0, input_type=np.array([1, 64, 64])
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "flatten"), ("flatten", "output")],
+    )
+
+    # undef flatten.input
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "flatten": nir.Flatten(start_dim=0, end_dim=0, input_type=None),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "flatten"), ("flatten", "output")],
+    )
+
+    # undef flatten.input and graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "flatten": nir.Flatten(start_dim=0, end_dim=0, input_type=None),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "flatten"), ("flatten", "output")],
+    )
 
 
-@pytest.mark.skip("Not implemented")  # TODO: Fix subgraph nodes for type checking
 def test_conv_type_inference():
-    graphs = {
-        "undef graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "conv": nir.Conv2d(
-                    input_shape=(64, 64),
-                    weight=np.zeros((1, 1, 4, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "incorrect graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "conv": nir.Conv2d(
-                    input_shape=(64, 64),
-                    weight=np.zeros((1, 1, 4, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=np.array([1, 61, 1])),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "undef conv.input": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "conv": nir.Conv2d(
-                    input_shape=None,
-                    weight=np.zeros((1, 1, 4, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=np.array([1, 61, 61])),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "undef conv.input and graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64, 64])),
-                "conv": nir.Conv2d(
-                    input_shape=None,
-                    weight=np.zeros((1, 1, 4, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "Conv1d undef graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64])),
-                "conv": nir.Conv1d(
-                    input_shape=64,
-                    weight=np.zeros((1, 1, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "Conv1d incorrect graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64])),
-                "conv": nir.Conv1d(
-                    input_shape=64,
-                    weight=np.zeros((1, 1, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=np.array([1, 3])),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-        "Conv1d undef conv.input and graph output": nir.NIRGraph(
-            nodes={
-                "input": nir.Input(input_type=np.array([1, 64])),
-                "conv": nir.Conv1d(
-                    input_shape=None,
-                    weight=np.zeros((1, 1, 4)),
-                    stride=1,
-                    padding=0,
-                    dilation=1,
-                    groups=1,
-                    bias=None,
-                ),
-                "output": nir.Output(output_type=None),
-            },
-            edges=[("input", "conv"), ("conv", "output")],
-        ),
-    }
-    for name, graph in graphs.items():
-        try:
-            # this should raise an exception
-            graph.check_types()
-        except Exception:
-            pass
-        else:
-            raise AssertionError(f"type check failed for: {name}")
-        graph.infer_types()
-        assert graph.check_types(), f"type inference failed for: {name}"
+    # TODO: Add assertions
+
+    # undef graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "conv": nir.Conv2d(
+                input_shape=(64, 64),
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None,
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "conv"), ("conv", "output")],
+    )
+
+    # undef conv.input
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "conv": nir.Conv2d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None,
+            ),
+            "output": nir.Output(output_type=np.array([1, 61, 61])),
+        },
+        edges=[("input", "conv"), ("conv", "output")],
+    )
+
+    # undef conv.input and graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64, 64])),
+            "conv": nir.Conv2d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None,
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "conv"), ("conv", "output")],
+    )
+
+    # Conv1d undef graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64])),
+            "conv": nir.Conv1d(
+                input_shape=64,
+                weight=np.zeros((1, 1, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None,
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "conv"), ("conv", "output")],
+    )
+
+    # Conv1d undef conv.input and graph output
+    nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([1, 64])),
+            "conv": nir.Conv1d(
+                input_shape=None,
+                weight=np.zeros((1, 1, 4)),
+                stride=1,
+                padding=0,
+                dilation=1,
+                groups=1,
+                bias=None,
+            ),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "conv"), ("conv", "output")],
+    )
 
 
 def test_node():

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -71,7 +71,14 @@ def factory_test_metadata(ir: nir.NIRGraph):
 
 
 def test_simple():
-    ir = nir.NIRGraph(nodes={"a": mock_affine(2, 2)}, edges=[("a", "a")])
+    ir = nir.NIRGraph(
+        nodes={
+            "input": nir.Input(input_type=np.array([2])),
+            "a": mock_affine(2, 2),
+            "output": nir.Output(output_type=None),
+        },
+        edges=[("input", "a"), ("a", "a"), ("a", "output")],
+    )
     factory_test_graph(ir)
     factory_test_metadata(ir)
 


### PR DESCRIPTION
This is my first stab at doing type inference, in addition to type checking, on graph construction (`NIRGraph.__init__`).

There are still a few things to do, so I put this up as a draft for now, but I think it would be a good idea for
people to have a first look and comment if this is going in the right direction.

All commits should have passing tests, so we can pick-and-chose if necessary

# Input and Output node handling
We automatically add Input and Output nodes if they are missing from the NIRGraph. Before, we only did this on NIRGraph.from_list, but we now do this on all graphs. This is a requirement for nested graphs, otherwise we can't validate the outputs from nested graphs against the data going in and out of it from the outer graph.

A major break is the requirement of Input and Output nodes to be present for graphs that have no non-ambiguous  inputs or outputs. This is the case for certain recurrent connections, for example:
```mermaid
graph LR
A --> B
B --> A
```
For this graph, it's impossible to know which one is the input/source node and which one is the output/sink node, so the type inference will throw an error.
This graph with a recurrent connection is fine:
```mermaid
graph LR
input --> A
A --> B
B --> A
A --> output
```

I think this change limits the flexibility of NIR in some way, at least when creating graphs with type inference/checking active, so needs careful thought.

TODO:
* [ ] Support nested graphs for both type checking and type inference
* [ ] Reactivate more currently skipped tests, that should be fixed with this change.
* [ ] Add some more specific tests for type inference