### PR TITLE
Support scalar parameters in type inference

### DIFF
--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -755,6 +755,25 @@ def test_type_check_recurrent():
         )
 
 
+def test_type_check_scalar_parameters():
+    graph = nir.NIRGraph.from_list(
+        nir.Linear(weight=np.random.randn(10, 20)),
+        nir.LIF(
+            tau=np.float32(4.0),
+            r=np.float32(1.0),
+            v_threshold=np.float32(1.0),
+            v_reset=np.float32(0.0),
+            v_leak=np.float32(0.0),
+        ),
+    )
+    assert graph.input_type["input"] == (20,)
+    assert graph.nodes["linear"].input_type["input"] == (20,)
+    assert graph.nodes["linear"].output_type["output"] == (10,)
+    assert graph.nodes["lif"].input_type["input"] == (10,)
+    assert graph.nodes["lif"].output_type["output"] == (10,)
+    assert graph.output_type["output"] == (10,)
+
+
 def test_node():
     try:
         node = nir.ir.NIRNode()


### PR DESCRIPTION
I am trying to import a NIR file exported by latest snnTorch from GitHub, and got an error in type inference.

Turns out that snnTorch uses numpy scalars like `np.float32(4.0)` to define parameters, which end up
as `input_type={'input': ()}` (empty tuple). This implies that the actual neuron count is not known on the neuron node.

Technically, snnTorch is wrong here, the type annotation for neurons call for a np.array, but because numpy scalar values like `np.float32` have a `.shape` property, this actually worked just fine before we introduced type inference.

Thankfully we are already doing type inference, and in most cases we can infer the number of neurons and therefore input_type and output_type from preceding nodes, and this is what I am doing here.