### PR TITLE
Add overview of supported NIR nodes per framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Discord](https://img.shields.io/discord/1209533869733453844?logo=discord)](https://discord.gg/JRMRGP9h3c)
 
 NIR is a set of computational primitives, shared across different neuromorphic frameworks and technology stacks.
-**NIR is currently supported by 7 simulators and 4 hardware platforms**, allowing users to seamlessly move between any of these platforms.
+**NIR is currently supported by 8 simulators and 5 hardware platforms**, allowing users to seamlessly move between any of these platforms.
 
 NIR is useful when you want to move a model from one platform to another, for instance from a simulator to a hardware platform.
 
@@ -41,6 +41,7 @@ See our [example section](https://neuroir.org/docs/examples) for how to use NIR 
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
+| [jaxsnn](https://github.com/electronic-visions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
 | [Lava-DL](https://github.com/lava-nc/lava-dl) | ✓ | ⬚ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
 | [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
 | [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |

--- a/docs/source/examples/jaxsnn/nir-conversion.ipynb
+++ b/docs/source/examples/jaxsnn/nir-conversion.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# jaxsnn\n",
+    "\n",
+    "[jaxsnn](https://github.com/electronicvisions/jaxsnn) is an event-based training framework for spiking neural networks (SNNs) implemented in JAX. It provides support for numerical model simulation.\n",
+    "\n",
+    "Training of SNNs is done in the init/apply style, where an `init` function contains the initial parameters and the `apply` function represents the forward pass as well as the backward pass through the SNN."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export a NIR graph from NIR to jaxsnn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import random\n",
+    "import jaxsnn\n",
+    "import nir\n",
+    "import numpy as np\n",
+    "\n",
+    "input_size = 3\n",
+    "output_size = 2\n",
+    "\n",
+    "np_rng = np.random.default_rng(42)\n",
+    "weight = np_rng.uniform(low=0.5, high=1.5, size=(output_size, input_size))\n",
+    "\n",
+    "# Create a simple NIR graph\n",
+    "nir_model = nir.NIRGraph(\n",
+    "    nodes={\n",
+    "        \"input\": nir.Input(input_type=np.array([input_size])),\n",
+    "        \"linear\": nir.Linear(weight=weight),\n",
+    "        \"cubalif\": nir.CubaLIF(\n",
+    "            tau_mem=np.array([4e-4]*output_size),\n",
+    "            tau_syn=np.array([2e-4]*output_size),\n",
+    "            r=np.array([1]*output_size),\n",
+    "            v_leak=np.array([0]*output_size),\n",
+    "            v_reset=np.array([-1]*output_size),\n",
+    "            v_threshold=np.array([1]*output_size),\n",
+    "        ),\n",
+    "        \"output\": nir.Output(output_type=np.array([output_size])),\n",
+    "    },\n",
+    "    edges=[(\"input\", \"linear\"), (\"linear\", \"cubalif\"), (\"cubalif\", \"output\")],\n",
+    ")\n",
+    "\n",
+    "# Convert to jaxsnn\n",
+    "config = jaxsnn.ConversionConfig(t_max = 4*2e-4,\n",
+    "                                 n_spikes = {\"cubalif\": 20})\n",
+    "init, apply = jaxsnn.from_nir(nir_model, config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that here, the `apply` function performs the forward pass as well as the backward pass (pure simulator).\n",
+    "It is also possible to perform the forward pass externally, e.g. on a [BrainScaleS-2](https://open-neuromorphic.org/neuromorphic-computing/hardware/brainscales-2-universitat-heidelberg/) chip or other neuromorphic hardware and use jaxsnn only for gradient computation on the external spike times. This needs to be specified by the `external` argument in the `ConversionConfig` object."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Test the network with some input spikes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlgAAAGHCAYAAABs5iy7AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAA/vElEQVR4nO3dB3RT5f/H8W+BFihQEFkiU4YispEpQ2WIylBUfoAsAcXFcoGDISpDQQUEJ+OnIhwVHCACyl6yHYCgbGQjswVayv2f78M//aVtOtLeNOO+X+fktLm5SZ6naZNPnxlmWZYlAAAAsE02+x4KAAAAioAFAABgMwIWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUgQ3755Re57777pFSpUpIzZ04pWrSo1K9fX5555pkMPd7evXslLCxMpk2blnBs2LBh5tiJEyfEbvo8+thpXcqUKWPO1++1PACQHjnSdRYAuJk3b560adNGmjZtKmPGjJHrrrtODh8+LBs2bJCZM2fK2LFjvX5MfYw1a9ZIuXLlJCvcc8895vncaUB84IEHEoVEDY9Kzy1RokSWlA1A8AtjL0IA3mrSpIn8888/8ueff0qOHIn/T7ty5Ypky2ZP47i2GA0fPlyOHz8uhQoVEl/TVqonn3xSJk6c6PPnAhDa6CIE4LWTJ0+awJM0XKmk4Uq72O69916ZM2eOVK1aVXLlyiU33HCDjB8/Ps0uQk801On969atK8eOHTPHjhw5Io899phpYYqIiJCyZcuaYHb58mWxS9IuQlcX4+LFi6V3795y7bXXSlRUlHTt2lWio6NNmR566CEpUKCAaZ179tlnJS4uLtFjxsbGymuvvSY33XSTaSkrXLiw9OjRwwRKd/oc2lqoz5E7d27TLdu+fXuJiYmxrX4A7EUXIQCvaVfaxx9/LH379pXOnTtLzZo1JTw8PMXzt2zZIv379zcBpVixYvL5559Lv379TMDQ4JFey5YtM+O+GjduLDNmzJDIyEgTZOrUqWOC3ZAhQ0wXo3bnaXDR0DZ16lTxpV69esn9999vukY3b94sL774ogl2O3bsMMcfffRR+emnn2T06NFSvHhxGThwYEJLX9u2bWXFihXy/PPPS4MGDWTfvn0ydOhQE6a0u1XDlNZBuzMbNWokU6ZMMYFNWw9//PFH8/PTnwGAAKRdhADgjRMnTli33XabDi8wl/DwcKtBgwbWyJEjrXPnziU6t3Tp0lZYWJi1ZcuWRMebN29uRUVFWdHR0eb6nj17zGNNnTo14ZyhQ4eaY8ePH7c+/fRTKyIiwurbt68VHx+fcM5jjz1m5c2b19q3b1+ix3/rrbfMfbdu3Zrueun5Tz75ZIq3aXlctJx67Omnn050Xrt27czxcePGJTpevXp1q2bNmgnXv/jiC3Pe119/nei89evXm+OTJk0y17/66itzPenPD0Bgo4sQgNe0q0pbXtavXy+jRo0yLTE7d+6UwYMHS5UqVZLN+qtcubJUq1Yt0bFOnTrJ2bNnZdOmTWk+3+uvvy7du3c3z/Xuu+8m6oacO3eu3H777aZ1SFuOXJdWrVoltHr5knZ/uqtUqZL5qq1OSY9rC5V7ubU1qnXr1onKXb16ddPKt3TpUnOeXtduT20Jmz59uuzevdun9QFgDwIWgAyrXbu2vPDCC/Lll1/KoUOHZMCAAaZLS2cWutPAkJTrmI7nSstnn30m119/vfznP/9JdtvRo0fl+++/N12U7hcNdcoXSzy4K1iwYKLrGoZSOn7x4sVE5T59+rQ5nrTs2u3pKrd2eWoXY5EiRcwAfL2uFw2aAAIXY7AA2EKDgY4fevvtt+WPP/5IdJsGhqRcx7Q1LC063qhDhw5mHNLPP/8spUuXTrhNB9vr4Hlt5fJEW7YCkZZb66518yRfvnwJ32u99RIfH2/GZk2YMMGMadO1xzyFTgD+R8AC4DVd80pnxiW1fft2j6Fm69at8uuvvybqJtRB6hoidIB8WjRQaZdks2bNEkJWhQoVErrofvjhB9Oqc80110iw0HLrwHgNTTojMj2yZ89uztVZhzpRQLtXCVhAYCJgAfBay5YtzZIIOn5IP+x1RpzOFNQFRvPmzWtmCLrTwKULk+osQg1m2uW3aNEiM7MuvbPg9H46nkqfW2cR6v1vueUWefXVV833OgtPZzXeeOONpitOuyo1eL3//vsBuUCoBiMNSXfffbf5eelMSG0FPHjwoCxZssSMa9MZk1p+XaZBx3Tp8gxaN51NqDRwAghMBCwAXnv55Zfl22+/Nd2B2pp16dIlE4D0A18HursGervoQG1d30m7EP/66y8TuMaNG2fGbHnbreYKG7rY6YIFC8w4MO02GzFihLz55psmoGjLmK6FdddddwVsq5a2Rn333XdmLNWnn34qI0eONOuKaRjUuulkAdfPbuHCheZnp92qGmA1WOp9W7Ro4e9qAEgBK7kD8CldaFQDgc6aAwCnYBYhAACAzQhYAAAANqOLEAAAwGa0YAEAANiMgAUAAGAzAhYAAIDNgnodLF3cUPc/0zVvwsLC/F0cAAAQ4izLknPnzpn1/Nw3ng+pgKXhqmTJkv4uBgAAcJgDBw6kuktEUAcs12aoWsmoqCifPEdcXJxZRVlXTNZtLJzAiXVW1Ns59XZinRX1dk69nVjnrKr32bNnTeOO+4bsIRewXN2CGq58GbB0rzR9fKf8kjqxzop6O6feTqyzot7OqbcT65zV9U5raBKD3AEAAGxGwAIAALAZAQsAAMBmQT0GK73TKS9fvizx8fEZ7s/NkSOHXLx4McOPEWycWOfU6q39+NmzZ/dr2QAAwSWkA1ZsbKwcPnxYYmJiMhXQihUrZmYqOmWtLSfWObV66/c6FTdv3rx+LR8AIHiEbMDSRUj37NljWh50MbCIiIgMhQV9nPPnz5sP19QWFAslTqxzSvXW0HX8+HE5ePCgVKhQgZYsAICzA5a2XukHpq5VoVM2M0ofQx8rV65cjgkbTqxzavUuXLiw7N2713QhErAAAOkR8p+eTgoI8A0ndZMCAOxB+gAAALBZyHYR2knH4fwbHSsX4q5Inpw55JrIcFo1AABAighYqThzIU6+2nBApq7aIwdPX0w4XrpgpHRrUEba1yoh+XM7ZwsCu5UpU0b69+9vLkpD65w5c6Rdu3b+LhoAAJlCF2EKlu08LvVH/iyvzdsu/7iFK7X/3xgZMXebuV3Ps1v37t39EjKmTZsmBQoUSPM8XSNq5MiRctNNN0nu3LmlYMGCUq9ePZk6dapXz7d+/Xp59NFHM1FiAAACEy1YHmho6jF1nVjaPejhdtexC3Hx5rypPepIk4qFxSmGDRsmH374oUycOFFq165tdhbfsGGDnDp1yqvH0dl5AACEIlqwPHQLPv7ZxqvhylO6cqO36yl6vt7PV5o2bSp9+/aV559/3rQW6WKYGnLcaffa5MmTpVWrVqZVqWzZsvLll18m3L506VJzzunTpxOObdmyxRzTJQj09h49esiZM2fMUgTXXHONDB8+3GN5vv/+e3niiSfkwQcfNM9TrVo16dmzpwwcODBRmZ966ilz0Vaxa6+9Vl5++WUzns29i/Cdd95Jsd6vvvqqFC1a1JRTrV69Who3bmzqp8tv6M8kOjo64fxJkyaZtap0mQW93wMPPOD1zxoAADsQsJL4euNBuRAbn2a4ctHz9PzZmw76tFzTp0+XPHnyyC+//CJjxowx4WPRokWJznnllVekffv28uuvv8rDDz8sHTt2lO3bt6fr8Rs0aGDCTlRUlPzzzz/y559/yjPPPOPxXA14ixcvNgtwplVm3XpGyzx+/Hh5++235eOPP06zLBrC+vXrJ5988omsXLlSqlevLr///ru0bNlS7r//fvntt99k1qxZ5jYNcEpb0DRw6c9lx44d8uOPP5owBgCAPxCwknywT1+9N0P3nbZqb6LWGbtVrVpVhg4dalpounbtarrmfv7550TnaItSr169pGLFijJixAhzzoQJE9L1+LrSff78+U2LlgYobQFKaWuYcePGmXCl52m5+vTpI/Pnz092nrYyaai68cYbpXPnzvL000+b66nRfSO1fgsXLpRVq1aZ+qo333xTOnXqZAbE6zENhBra/vvf/5q9A/fv328C6L333iulS5eWGjVqmMAFAIA/ELDcnIqJk33/xngcd5UaPV/vdzrGd92EGmTcXXfddXLs2LFEx+rXr5/senpbsLxx8803yx9//CFr16413YpHjx6V1q1bm3DnTge+uy9noeX566+/Ut1AesCAAbJmzRpZsWKF2f/PZePGjWYQvoY+10VbtFxbIjVv3twEqxtuuEG6dOkin3/+eab2oAQAIDMIWG6iL13O1P3PZ/L+qQkPT7wchAYXDRdpcQUc9731XHTrl4zSx7v11ltNINKlFTT8aJeehp3M0KCkXZQLFixIdFzr+thjj5nxWK6LdoVqYCtXrpzky5dPNm3aJF988YUJn0OGDDFjw9zHnAEAkFUIWG50EdHMyJvJ+2eWtiglva5LKbjP2Dt8+HDC7a7B4+7dhKm1LqXVqqXcB517Kk9aGya3adNGZsyYYVrDZs6cmXC8Zs2asnXrVilfvnyyi5Zb6XivZs2amTFqOk5LB+/rWDEAALIayzS40RXadRHR/V52E2obUamCkVIg0r+LjuqsQR13ddttt5kusnXr1plWJaVBRMdE6ezD1157zbT8jB07NtH9dVbf+fPnzdgu7WrTwOJpHJbOzmvYsKEZB6XjsLTVavDgwWbslyvQqQMHDpiZhdrypK1LOh4s6XN6ct9998mnn35quvq0DPp8L7zwgulyfPLJJ6V3795mvJV2f+pAf33cuXPnyu7du83Adp0B+cMPP5hWLx3/BQBAVqMFK0l3mq7QnhHdG5bx+/Y5uqyCtvroeC2dwachy9WypF2M2n2mswO162z06NEmaLnTwKQD1nX2oQYyHVjuiY590qUadNyVhqpu3bqZYKUD0zUQuehg9QsXLkidOnVMMNJB7uldWFRDldZBQ9bs2bNNnZYtW2aCYaNGjcwgdp01qd2BSpeC0PPuuOMOqVSpkrz//vumvpUrV87ETxQAIHEX/F2CoEQLVhK6/c1bC3eYRUTTMykwW5hIrvDscn/N/w3Iziwdz+RO16hK6ptvvkl2rHjx4ibkpERbnbTrzF3SmY+6ltZ7771nFg/VJRs80RYkvaRFQ50u/aCP6Yl24aVWloceeshcXHTMV0r101Y7Tz8nAEAm7F0l8ll7kS6zRUo38HdpggotWEno3oKTH65luv3SapBy3f7+w7XYkxAAEHoWjxC5fEHk51f9XZKgQ8DyQLe90e1vcodnvxq0ktzuOqa3T+tRRxo7aJscAIBD7Fkhsn/N1e/1q15H8AUs3TxYxzDpQpKBErLWDL5TXrm3klxfIFei23RA+5DWN8vaF+8MmHCl3Wv+2CA6Jdpdl9o2OACAALfkdZGw/5/1rV/1OoJrDNb69evN5sFJF9P0N+32696gjNxX+Rq5Ep5bYmKvmKUYdLagvwe0AwCQJa1Xyor/XytW2Ub+LFnQ8HsLli4LoNuofPTRR2Z6fSDSMHVNZISULBgp1+SJIFwBAJzTeuVCK1ZwtWDp9P177rnHLBCZdNmApC5dumQuLjrTzbUiedJVyfW6dpvpWkjpWfE8Ja6Zba7HcgIn1jm1euv3ekx/p1JbJDVYuf52MrOyf7BxYp0V9XZOvTNV531rRA5uFgkLv3pxp8f/Xi5SOvHWbE56rePS+dhhli93KE6Drtn0+uuvmy7CXLlySdOmTaV69eopjt3RRTJ1raekdOXvyMjIRMd0PSZdBFMX13St9A1kRGxsrFk09ciRI2YzagCAc8XExEinTp3kzJkzKS5n5NeApR9Yuuq4rmukC1+qtAKWpxYsDVAnTpxIVsmLFy+a59DVyTW8ZZT+eM6dO2f2unNK16AT65xavfV3Sdfs0t+1zPwuBSr9b0xXxNd9IJPueRmqnFhnRb2dU+8M11lbr2Y8mPZ5nb4MyFasuCx4rTV7FCpUKM2A5bcuwo0bN8qxY8ekVq1aCcd0H7zly5fLxIkTTZBK2h2TM2dOc0lKf4hJf5D6WPohqZsSuzY6zghXV5F5rPhLIuG5JdQlqnMmfnahUm/9Xo95+j0LJaFeP0+cWGdFvZ3D6zovf0PEirs6qD0lOhZLz3vkR3Hiax2ezsf126fnnXfeKb///rvZcNh10RYtHfCu3wfcWJd9q0RGlxXZt9rfJXEs7SLWFk6X7t27B9TSFAAQEjMHUwtXSWcUIvAClnbD3HLLLYkuuoHvtddea74PNGGLX8vS1Wy1e7Nnz55m+xsdQ1a6dGnp16+fnDx50qvH0a4tbX3R0OoL+tietu1JasmSJXL77bdLwYIFzXi5ChUqmD0MvRnT9Oyzz5qNqAEAWTRzMCXMKEyTc/p/MiHHgTUSdmDt1StZkNp3795tWvN27txpNiz++++/zebFGi7q168v//77rwSTrVu3SqtWrcxegtoFrC2XEyZMMM2s3sxSzJs3rwngAAA/tV650IoVXAErUFf/zrVmrFhZuJqtLl2hrVY6AaBJkyZSqlQpE1B++ukn+eeff+Sll15KtQWpQIECCRtGly1b1nytUaOGOVcnErh3r+mszCJFipiBeo899piZMedyww03JHs9tItOu+qUTiBQ9913n3ls1/WkdMDhddddJ2PGjDGtk+XKlZO77rpLPv7444QZnlpeLbfWpWLFimYwuQ5S1Ja8lLoIPY3r07rozFSlAxAfffTRhPrdcccd8uuvvyacr99rq5q2purtGgA3b96c5usDACHHfK55O6kpjFasYAlYAWnvSslxaL2EuVK9j1O7tk4tWLBAnnjiCcmdO/GAel12QseozZo1K2HNprSsW7fOfNVwdvjwYZk9e3bCbdoitn37dtN9py1lc+bM8bgMRkp0eQ01depU89iu60lpufV2bb1Ka+qrhqPp06fLqlWrzEyN//znP+kO5zquT8uvAVR/Prq+mi6t8MMPP5jwVbNmTXOOqwVQf5YlSpQw5dbbn3/+ebO8BwA4Smy0yEF9//Z2UQHr6v1iY3xUsODGp0kawpa8blqvEgKWeytWWftnUPz1118mHFSqVMnj7Xr81KlTcvz4cdMyk5bCha/ulahdaxp03Gnr0ZQpU8yYqMqVK8urr74qzz33XLpDluuxteUp6WO7e/DBB01o1NY4Pa9evXom6HTt2jXRFFedXqszSOvWrWuua9DS+mpIrFOnToqP/+2330qXLl3kgw8+kI4dO5pjGhq1K1Jnqrpmnr711lumheyrr74yLVv79+839b3pppvM7dqy5lq8FgAcIyKPyDM7RC6e8f6+ufKLRCRehxJX0YKVmj0rzNirROHKz33PrpYrO9an0vXH3Bdo1fFdunWRe7ecHXRGqLZyHTx40HQT6sB9banSUKctWy7aeqRjz1w0+Gh401a2lPzyyy/Svn17E8Zc4Uppi5TWRYOljt1yXfbs2SO7du0y5wwcOFB69epldhEYNWpUwnEAcJw8hUSuLef9Re8HjwhYqfn/1iuPfDQWq3z58iY8bdu2zePtf/75p9mzURc5M8UIC0vWXZjZLQJc4U3Xf7Lzsa+//nrT0vTee++Z+ukCnjp439Nzp3XMRVudNIhpS5z7+DEdPK/jvtyXAdHLjh07TKuVa0yXDsDXrsTFixeb8WFz587NcP0AAHAhYKUxoyJZ65WPW7G0xUUHd0+aNEkuXLiQ6DYdT/T5559Lhw4dEkKHdtO5twJpF6OOZXJxDSLXhVeT0kHe7s+xdu1a08qj45I8PbZ2n2kLkDudCejpsdOiIVEDUHR0dMIxXbJhw4YNCdc1DJ0+fTqhC88TDZoajrT1SX8urgCo463056WtYhpa3S+ucKp0QP2AAQPMhAIdrK8/XwAAMouAlZn1QHzUiuVayb5ly5ZmYLh22f34448meGkrkGuWnNKZcXr+pk2bTDjp06dPolVmdZyWDpbX+x89etTMrHPRFh9da0tbk+bPny9Dhw6Vp556KmEVc51h9+mnn8qKFSvkjz/+MOtWJV0AVmcO6mB5DTM6NswTHRv1+OOPmxCjQUhbjV544QXztXXr1gnnabmffvpp0+2n9enRo4cZr5Xa+CtXHTVkaeuedhNqUNNuP+3y1JmSOv5L1wNbvXq1vPzyy+bnpMFS66qD4/ft22cG1etxDVwAAGQWASsAV7PVRTj1w167v7RVRr/qoGwNPGvWrDGLdbqMHTvW7JHXuHFjs/mkLsbpPq5KW3DGjx9vQo6OfWrbtm3CbTrQXJ9L7/vQQw+ZsONagkENGjTI3HbvvffK3XffbcKKlsWdPr8uw6Bl0KUgPNGApOOhNPzpuCsd7K6tZTrgXL930XJr8NJ6aDjSYKgbgqeHDp7XkKUD23V2oHYR6uxBLf8jjzxigpPOSNSgVbRoURMUddFWHWivt2n9demIwYMHp/NVAgBAAm+zZztol1X+/Pk9brio43u0O0vXgfJ6g94pd4kcWJe+Bde0FatknYDek8kTXQdLu988rcKu4UR/tvozzaq9CHUdrP79+5sy+UtK9c7U71IQ0G5VDaMaop2yT5sT66yot3Pq7cQ6Z1W9U8se7mjBSorVbAEAQCYRsJJiNVsAAJBJBCyHrmarXXLp2aQ5q7ssAQAIBazknsZqtlcsywzQ1uULsqW2uCer2QIAAKcELK/H8OuqtO4r0165IldynBXRgWxZNOAbgSWI54EAAPwkZBODa/aA+6KbQEa4VohPugYYAACOa8HSD0Pdx043+3WtsZSR/ft06r5+wOpU/axassDfnFjnlOqtx3Rjbf390TXFAABIj5D+xNDFJ5UrZGW0e0hX/dZFL+3YYDkYOLHOqdVbw1apUqUc9bMAAGROSAcs/UDU/e50K5WMblKs99PtanRFcKcs1ubEOqdWb93P0UkteQCAzAvpgOXeXZjR8TN6P93bTlfwdkrYcGKdnVxvAID9+LccAADAZgQsAAAAmxGwAAAAbEbAAgAAsBkBCwAAwGYELAAAAJsRsAAAAGxGwAIAALAZAQsAAMBmBCwAAACbEbAAAABsRsACAACwGQELAADAZgQsAAAAmxGwAAAAbEbAAgAAsBkBCwAAwGYELAAAAJsRsAAAAGxGwAIAALAZAQsAAMBmBCwAAACbEbAAAABsRsACAACwGQELAADAZgQsAAAAmxGwAAAAbEbAAgAAsBkBCwCA9Iq74O8SIEgQsAAASI+9q0RGlxXZt9rfJUEQIGABAJAei0eIXL4g8vOr/i4JggABCwCAtOxZIbJ/zdXv9ateBwI1YE2ePFmqVq0qUVFR5lK/fn2ZP3++P4sEAEByS14XCct+9Xv9qteBQA1YJUqUkFGjRsmGDRvM5Y477pC2bdvK1q1b/VksAACSt15Z8Vev61dasRDIAat169Zy9913S8WKFc3l9ddfl7x588ratWv9WSwAADy3XrnQioU05JAAER8fL19++aVER0ebrkJPLl26ZC4uZ8+eNV/j4uLMxRdcj+urxw9ETqyzot7OqbcT66yodwbqvW+NyMHNImHhVy/u9Pjfy0VKe/7M8ide6zifP0dawizLssSPfv/9dxOoLl68aFqvZsyYYVq1PBk2bJgMHz482XG9T2RkZBaUFgAAOFlMTIx06tRJzpw5Y8aPB2zAio2Nlf3798vp06fl66+/lo8//liWLVsmN998c7pasEqWLCknTpxItZKZTaqLFi2S5s2bS3h4kv9eQpQT66yot3Pq7cQ6K+rtZb219WrGg2mf1+nLgGvF4rVu7rN6a/YoVKhQmgHL712EERERUr58efN97dq1Zf369fLuu+/KBx98kOzcnDlzmktS+kP09S9QVjxHoHFinRX1dg4n1llR73Ra/oaIFfe/we2e6FgsPe+RHyUQ8VrbL72PG3DrYGmDmnsrFQAAfp85mBJmFCIQW7BefPFFadWqlenmO3funMycOVOWLl0qP/4YmP8JAAAcNnMwrYDlPqOwLJ9dCJCAdfToUenSpYscPnxY8ufPbxYd1XClfacAAPh91fb0cG/FKtvIlyVDEPFrwPrkk0/8+fQAACRn1rcK0+TkxZ3CaMVCYI/BAgDAb2KjRQ6u9zJcKevq/WJjfFQwBBu/zyIEACBgROQReWaHyMUz3t83V36RCNZkxFUELAAA3OUpdPUCZAJdhAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAADg74B14cKFFG/TPQUBAACczuuAVaNGDdm0aVOy41999ZXZrBkAAMDpvA5YzZs3lwYNGsioUaPEsiw5f/68dO/eXbp16yZDhgzxTSkBAABCeaucCRMmyD333CM9evSQefPmyaFDhyQqKkrWr18vN998s29KCQAAEOp7EbZo0ULuv/9+mTx5suTIkUO+//57whUAAEBGuwh37dol9evXl7lz58qCBQvk+eefl7Zt25qvcXFx3j4cAABAyPE6YFWvXl3Kli0rv/76qxmP9dprr8nixYtl9uzZUqdOHd+UEgAAIJQD1qRJk2TmzJlSoECBhGM66H3z5s1Ss2ZNu8sHAAAQ+gGrS5cu5mtsbKzs2LFDLl++bK7ny5dPPvnkE/tLCAAA4ISFRnv27CmRkZFSuXJl2b9/vznet29fGT16tC/KCAAAENoBa9CgQWb81dKlSyVXrlwJx5s1a2a6DgEAAJzO62UavvnmG5k1a5bUq1dPwsLCEo7rMg06wxAAAMDpvG7BOn78uBQpUiTZ8ejo6ESBCwAAwKm8Dli33nqrWcHdxRWqPvroI7M+FgAAgNN53UU4cuRIueuuu2Tbtm1mBuG7774rW7dulTVr1siyZct8U0oAAIBQbsHSNa9WrVolMTExUq5cOVm4cKEULVrUBKxatWr5ppQAAAChvhdhlSpVZPr06faXBgAAwCkB6+zZs+l+wKioqMyUBwAAwBkBS7fFSe8Mwfj4+MyWCQAAIPQD1pIlSxK+37t3r1lstHv37gmzBnX8lXYZ6gB4AAAAp0tXwGrSpEnC96+++qqMGzdOOnbsmHCsTZs2ZlzWhx9+KN26dfNNSQEAAEJ1FqG2VtWuXTvZcT22bt06u8oFAADgnIBVsmRJef/995Md/+CDD8xtAAAATuf1Mg1vv/22tG/fXhYsWGD2I1Rr1641+xB+/fXXvigjAABAaLdg3X333fLXX3+ZcVf//vuvnDx5Utq2bSs7d+40twEAADhdhhYaLVGihLzxxhv2lwYAAMCpAev06dNmQPuxY8fkypUriW7r2rWrXWUDAABwRsD6/vvvpXPnzhIdHS358uVLtACpfk/AAgAATuf1GKxnnnlGHnnkETl37pxpyTp16lTCRcdkAQAAOJ3XAeuff/6Rvn37SmRkpG9KBAAA4LSA1bJlS9mwYYNvSgMAAODEMVj33HOPPPfcc7Jt2zazPU54eHii23X5BgAAACfzOmD17t07YU/CpHSQe3x8vD0lAwAAcErASrosAwAAADI5BgsAAAA2tWCNHz8+XefpDEMAAAAny+HNJs9p0TFYBCwAAOB06Q5Ye/bs8W1JEBAsy5JTMbHme/1aOCpHotX6AQCBjffxIN6LEKHnzIU4+XrjQZm+eq8cORMtY+qINBqzRIrlzyPdGpSR9rVKSP7ciZfkAAAEDt7HAwsBC7Js53F5/LONciH26hIbEdn/d9v+f2NkxNxt8tbCHTL54VrSpGJh/xUUAOAR7+OBh1mEDqd/lD2mrpMLcfFiadNykttdx/R2PU/PBwAEDt7HA5NfA9bIkSPl1ltvlXz58kmRIkWkXbt2smPHDn8WyXHNyfofj/njS/oXmYTerqfo+Xo/AID/8T4euPwasJYtWyZPPvmkrF27VhYtWiSXL1+WFi1aSHR0tD+L5RjaV6/NyWn9UbroeXr+7E0HfV00AEA68D4eYmOwdDX3v//+W44dO5ZsZffGjRun+3F+/PHHRNenTp1qWrI2btzo1eMgY7NMdCBkRkxbtVe6NyjDrBQA8CPex0MsYGlrU6dOnWTfvn3mxbVzL8IzZ86YrwULFvR4+6VLl8zF5ezZs+ZrXFycufiC63F99fj+olN3dZaJ+0BIl5zZrERfk9L7nTgbIwUiIySUhOprnRYn1tuJdVbUO7Tqzfu4f17r9D52mJU0JaWhevXqUrFiRRk+fLhcd911ydJv/vz5JSO0GG3btpVTp07JihUrPJ4zbNgw87xJzZgxQyIjIzP0vAAAAOkVExNjGpq0USgqKsq+gJUnTx759ddfpXz58mInHYs1b948WblypZQoUSLdLVglS5aUEydOpFrJzCZVHR/WvHlzCQ8PD6n/fHR9FE/0P54Rta/IKxuyyaUrnpuPVz5/e0j+5xOKr3VanFhvJ9ZZUe/Qqjfv4/55rTV7FCpUKM2A5XUXYd26dc34KzsD1tNPPy3fffedLF++PMVwpXLmzGkuSekP0dd/NFnxHFlJV/bVxed0fZSUErb+UV6KT/yHqddKFYyUQlGRIdt3H2qvdXo5sd5OrLOi3qGB93H/vNbpfdwcGQlDzzzzjBw5ckSqVKmS7ImqVq2a7sfSxjN9vDlz5sjSpUulbNmy3hYHGaR/VLqyry4+563uDRkYCQD+xvt4YPM6YLVv3958feSRRxKO6YukYcnbQe7aLajjp7799luzFpaGNtc4rty5c3tbNHhJt03QlX3N4nTp6CjOFiaSKzy73F8z5VZGAEDW4X08hAKWnZs+T5482Xxt2rRpsuUaunfvbtvzwDPdk0q3TdCVfbXNOLU/Ttc/Ou8/XIu9rAAgQPA+HkIBq3Tp0rY9uZfj6+EDuifV1B51Eu1h5c7VgJw7PLv5o2zMHlYAEFB4Hw9MGVpodNeuXfLOO+/I9u3bTbdgpUqVpF+/flKuXDn7S4gs+eNcM/hOs7KvLj6n66O46EBI7avXZuioXPzHAwCBiPfxEAhYCxYskDZt2pj1sBo2bGhaoVavXi2VK1eW77//3kyNRPDR5uIeDcualX118bnVS38yU3hDeZYJAIQS3seDPGANGjRIBgwYIKNGjUp2/IUXXiBgBTn9I3Sti6Jf+aMEgODC+3iQbvas3YI9e/ZMdlxnFW7b5v1UUQAAAHF6wCpcuLBs2bIl2XE9phs1AwAAOJ3XXYS9e/eWRx99VHbv3i0NGjQwTY+6vc3o0aPNAqQAAABO53XAeuWVV8yioGPHjpXBgwebY8WLFzcbMfft29cXZQQAAAjdgHX58mX5/PPPpWPHjmag+7lz58xxDVwAAADIwBisHDlyyOOPPy6XLl1KCFaEKwAAgEwOcq9bt65s3rzZ27sBAAA4htdjsJ544gkzmP3gwYNSq1YtyZMnT6Lbq1atamf5AAAAQj9gdejQwXx1H9CuMwl1RXf9Gh+ffB8kAAAAJ/E6YO3Zs8c3JQEAAHBqwCpdurRvSgIAAODUgPXf//431du7du2amfIAAAA4L2D169cv0fW4uDiJiYmRiIgIiYyMJGABAADH83qZhlOnTiW6nD9/Xnbs2CG33XabfPHFF74pJQAAQCgHLE8qVKggo0aNSta6BQAA4ES2BCyVPXt2OXTokF0PBwAA4JwxWN99912i67r+1eHDh2XixInSsGFDO8sGAADgjIDVrl27RNd1cdHChQvLHXfcIWPHjrWzbAAAAM4IWFeuXPFNSQAAAJw+Bis2NtbMHrx8+bK9JQIAAHBawNI1rx555BGz5lXlypVl//79CXsT6kxCAAAAp/M6YA0ePFh+++03Wbp0qeTKlSvheLNmzWTWrFl2lw8AACD0x2B98803JkjVq1fPDHB3ufnmm2XXrl12lw8AACD0W7COHz8uRYoUSXY8Ojo6UeACAABwKq8D1q233irz5s1LuO4KVR999JHUr1/f3tIBAAA4oYtw5MiRctddd8m2bdvMDMJ3331Xtm7dKmvWrJFly5b5ppQAAACh3ILVoEEDWbVqlZlNWK5cOVm4cKEULVrUBKxatWr5ppQAAACh3IKlqlSpItOnT7e/NAAAACHAts2eAQAA4GULVrZs2dKcJai3s7I7AABwunQHrDlz5qR42+rVq2XChAliWZZd5QIAAAj9gNW2bdtkx/7880+zsvv3338vnTt3lhEjRthdPgAAAGeMwTp06JD07t1bqlataroEt2zZYga9lypVyv4SAgAAhHLAOnPmjLzwwgtSvnx5s/bVzz//bFqvbrnlFt+VEAAAIFS7CMeMGSOjR4+WYsWKyRdffOGxyxAAAABeBKxBgwZJ7ty5TeuVdgemtA7W7Nmz7SwfAABA6Aasrl27spkzAACAnQFr2rRp6T0VAADA0VjJHQAAwGYELAAAAJsRsAAAAGxGwAIAALAZAQsAAMBmBCxAxGxUfiom1nyvX9m4PHTxWgMIqGUagFB05kKcfL3xoExfvVeOnImWMXVEGo1ZIsXy55FuDcpI+1olJH/ucH8XEzbgtQaQlQhYcKxlO4/L459tlAux8eZ6RPb/3bb/3xgZMXebvLVwh0x+uJY0qVjYfwVFpvFaA8hqdBHCsR+4Paaukwtx8aIdREk7iVzH9HY9T89HcOK1BuC4gLV8+XJp3bq1FC9e3GzD88033/izOHBQV5G2ZpgP1jSG3+jteoqer/dDcOG1BuDIgBUdHS3VqlWTiRMn+rMYcBgdh6NdRekd26zn6fmzNx30ddFgM15rAI4cg9WqVStzAbKKzhjTQc4ZMW3VXuneoAybngcJXmsA/hRUg9wvXbpkLi5nz541X+Pi4szFF1yP66vHD0ShXGedlq8zyNwHObvkzGYl+pqU3u/E2RgpEBkhoSRUX29ea+e81mlxYr2dWOesqnd6HzvMCpBFYPQ/xTlz5ki7du1SPGfYsGEyfPjwZMdnzJghkZGRPi4hAABwupiYGOnUqZOcOXNGoqKiQiNgeWrBKlmypJw4cSLVSmY2qS5atEiaN28u4eHOWCMnlOusrRq69pEn2poxovYVeWVDNrl0xXPX0Mrnbw/JVo1QfL15rZ3zWqfFifV2Yp2zqt6aPQoVKpRmwAqqLsKcOXOaS1L6Q/T1L1BWPEegCcU6F47KYRaW1LWPUvrPQj9wL8Un/tDVa6UKRkqhqMiQHZcTaq83r7VzXuv0cmK9nVhnX9c7vY/LOlhwFP3A1FW7M6J7QwY9BxNeawD+5NeAdf78edmyZYu5qD179pjv9+/f789iIcTplii5I7JLej8/s4WJOf/+miV8XTTYjNcagCMD1oYNG6RGjRrmogYOHGi+HzJkiD+LhRCn+83plij6mZvWB6/r9vcfrsU+dUGI1xqAIwNW06ZNzVo1SS/Tpk3zZ7HgALrf3NQedSR3eParH75Jbncd09un9agjjdmfLmjxWgPwh6Aa5A7Y/cG7ZvCdZtVuXVhS1z5y0UHOOg5Hu5iictGaEex4rQFkNQIWHE27gno0LGtW7daFJVcv/clMzw/lGWROxWsNICsxixD4/xlnrjWP9CsfuKGL1xpAViBgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAABgMwIWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAABgMwIWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAABgMwIWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ClwrIsORUTa77Xr3odABA8eB+Hv+Tw2zMHsDMX4uTrjQdl+uq9cuRMtIypI9JozBIplj+PdGtQRtrXKiH5c4f7u5gAgBTwPg5/I2AlsWzncXn8s41yITbeXI/I/r/b9v8bIyPmbpO3Fu6QyQ/XkiYVC/uvoAAAj3gfRyCgizDJH2WPqevkQly8aCNy0oZk1zG9Xc/T8wEAgYP3cQQKvwesSZMmSdmyZSVXrlxSq1YtWbFihd+ak/U/HvPHl0YXvd6up+j5ej8AgP/xPo5A4teANWvWLOnfv7+89NJLsnnzZmnUqJG0atVK9u/fn+Vl0b56bU5O7/hHPU/Pn73poK+LBgBIB97HEUj8GrDGjRsnPXv2lF69ekmlSpXknXfekZIlS8rkyZOztBw6q0QHQmbEtFV7mZUCAH7G+zgCjd8GucfGxsrGjRtl0KBBiY63aNFCVq9e7fE+ly5dMheXs2fPmq9xcXHmklE6dVdnmbgPhHTJmc1K9DUpvd+JszFSIDJCQoXrZ5mZn2kwot7OqbcT6xzq9eZ93Dmvtb/rnd7HDrP8FNsPHTok119/vaxatUoaNGiQcPyNN96Q6dOny44dO5LdZ9iwYTJ8+PBkx2fMmCGRkZE+LzMAAHC2mJgY6dSpk5w5c0aioqICd5mGsLCwRNc17yU95jJ48GAZOHBgohYs7VLUVq/UKpme/3x0fRRP9D+eEbWvyCsbssmlK57LtfL520PuP59FixZJ8+bNJTzcOevEUG/n1NuJdQ71evM+7pzX2t/1dvWepcVvAatQoUKSPXt2OXLkSKLjx44dk6JFi3q8T86cOc0lKf0hZuYHWTgqh1l8TtdHSak5T/8oL8Un/sPUa6UKRkqhqMgUQ2Ewy+zPNVhRb+dwYp1Dtd68jzvntfZ3vdP7uH4b5B4REWGWZdCk6U6vu3cZZgX9o9KVfTOie8MyIflHCQDBhPdxBBq/ziLU7r6PP/5YpkyZItu3b5cBAwaYJRr69OmT5WXRbRNyR2SX9P6NZQsTc/79NUv4umgAgHTgfRyBxK8Bq0OHDmZphldffVWqV68uy5cvlx9++EFKly6d5WXRPal02wT9u0zrj9N1+/sP12IvKwAIELyPI5D4fSX3J554Qvbu3WuWX9BlGxo3buy3suieVFN71JHc4dmv/oEmud11TG+f1qOONGYPKwAIKLyPI1D4fRZhIP5xrhl8p1nZVxef0/VRXHQgpPbVazN0VC7+4wGAQMT7OAIBAcsDbS7u0bCsdG9Qxiw+t3rpT2YKb6jOMgGAUMP7OMTpXYSBTP8IXeui6Ff+KAEguPA+Dn8hYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAABgMwIWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDNCFgAAAA2I2ABAADYjIAFAABgMwIWAACAzQhYAAAANsshQcyyLPP17NmzPnuOuLg4iYmJMc8RHh4uTuDEOivq7Zx6O7HOino7p95OrHNW1duVOVwZJCQD1rlz58zXkiVL+rsoAADAQc6dOyf58+dP8fYwK60IFsCuXLkihw4dknz58klYWJjPkqoGuAMHDkhUVJQ4gRPrrKi3c+rtxDor6u2cejuxzllVb41NGq6KFy8u2bJlC80WLK1YiRIlsuS59IVy0i+pU+usqLdzOLHOino7hxPrnBX1Tq3lyoVB7gAAADYjYAEAANiMgJWGnDlzytChQ81Xp3BinRX1dk69nVhnRb2dU28n1jnQ6h3Ug9wBAAACES1YAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWCIyadIkKVu2rOTKlUtq1aolK1asSPX8ZcuWmfP0/BtuuEHef/99CeU6Hz58WDp16iQ33nijWdy1f//+Eqy8qffs2bOlefPmUrhwYbNgXf369WXBggUS6vVeuXKlNGzYUK699lrJnTu33HTTTfL2229LqP9du6xatUpy5Mgh1atXl2DkTb2XLl1qdsFIevnzzz8l1F/vS5cuyUsvvSSlS5c2M87KlSsnU6ZMkVCtc/fu3T2+1pUrV5ZQf60///xzqVatmkRGRsp1110nPXr0kJMnT/q+oJbDzZw50woPD7c++ugja9u2bVa/fv2sPHnyWPv27fN4/u7du63IyEhznp6v99P7f/XVV1ao1nnPnj1W3759renTp1vVq1c35wcjb+utt48ePdpat26dtXPnTmvw4MHm/ps2bbJCud5avxkzZlh//PGHee0//fRT8zv/wQcfWKFaZ5fTp09bN9xwg9WiRQurWrVqVrDxtt5LlizRWeTWjh07rMOHDydcLl++bAWTjLzebdq0serWrWstWrTI/J7/8ssv1qpVq6xQrbP+bru/xgcOHLAKFixoDR061AomM72s94oVK6xs2bJZ7777rvn81uuVK1e22rVr5/OyOj5g1alTx+rTp0+iYzfddJM1aNAgj+c///zz5nZ3jz32mFWvXj0rVOvsrkmTJkEbsDJTb5ebb77ZGj58uOW0et93333Www8/bIV6nTt06GC9/PLL5kMnGAOWt/V2BaxTp05Zwczbes+fP9/Knz+/dfLkSStYZfbves6cOVZYWJi1d+9eK5Tr/eabb5p/mtyNHz/eKlGihOVrju4ijI2NlY0bN0qLFi0SHdfrq1ev9nifNWvWJDu/ZcuWsmHDBomLi5NQrHMosKPeurm4bvBZsGBBcVK9N2/ebM5t0qSJhHKdp06dKrt27TKLFAajzLzWNWrUMF0nd955pyxZskRCvd7fffed1K5dW8aMGSPXX3+9VKxYUZ599lm5cOGCOOXv+pNPPpFmzZqZLtJgEZuBejdo0EAOHjwoP/zwg9mk+ejRo/LVV1/JPffc4/PyBvVmz5l14sQJiY+Pl6JFiyY6rtePHDni8T563NP5ly9fNo+nb1KhVudQYEe9x44dK9HR0fLQQw+JE+qtG6kfP37c/G4PGzZMevXqJaFa57/++ksGDRpkxnLo+KtglJF66/vVhx9+aMax6JikTz/91IQsHZvVuHFjCdV6796924w11DE8c+bMMY/xxBNPyL///hsU47Ay+36m42rnz58vM2bMkGByIgP11oClY7A6dOggFy9eNO9nbdq0kQkTJvi8vMH5TmIzHejnTlNu0mNpne/peCjVOVRktN5ffPGFCRnffvutFClSRJxQbw0b58+fl7Vr15rwUb58eenYsaOEWp31DVsncQwfPty0ZAQ7b15rnbiiFxedyHHgwAF56623giZgZaTe2hqtt+kHb/78+c2xcePGyQMPPCDvvfeemdwRyu9n06ZNkwIFCki7du0kGIV5Ue9t27ZJ3759ZciQIaa3ScPlc889J3369DGteL7k6IBVqFAhyZ49e7Lke+zYsWQJ2aVYsWIez9f/enXWVSjWORRkpt6zZs2Snj17ypdffmma1J1Sb52lo6pUqWKa1TVgBkPA8rbO2u2rXfzaFfrUU08lfADrm7b+XS9cuFDuuOMOccrfdr169eSzzz6TYJGRemvLnXYNusKVqlSpknnNtTupQoUKEqqvtdZRW+m6dOkiEREREkwKZaDeI0eONLOiNVSpqlWrSp48eaRRo0by2muv+bTXydFjsPSXS5vGFy1alOi4XtdmRU/0P7yk5+sbsPbnh4eHSyjWORRktN7acqXTm7UpPSv67AP19dY3Ze1CCsU66xIcv//+u2zZsiXhov/dasuOfl+3bl1x0mutQTPQhzpktt76gXvo0CHTQuuyc+dOswyNdo2H8mutywz9/fff5p/GYBORgXrHxMSY19WdhjTl862YLYdzTfn85JNPzJTP/v37mymfrpkVOjOhS5cuyZZpGDBggDlf7xesyzSkt85q8+bN5lKrVi2rU6dO5vutW7dawcTbeutSBTly5LDee++9RNObdbpzKNd74sSJ1nfffWeWptDLlClTrKioKOull16yQvl33F2wziL0tt5vv/22mU2mr7Muy6G368fC119/bYVyvc+dO2dmkT3wwAPmfWzZsmVWhQoVrF69elmh/juus4F1eYpgNdPLek+dOtW8j0+aNMnatWuXtXLlSqt27dpmNqKvOT5gKf0ALV26tBUREWHVrFnT/LG5dOvWzSxN4G7p0qVWjRo1zPllypSxJk+ebIV6nfVNN+lF7x/K9dbvPdVbzwvleusUZl0nRv+R0GClv+v65hQfH2+F8u94KAQsb+ut67yVK1fOypUrl3XNNddYt912mzVv3jwrGHn7em/fvt1q1qyZlTt3bhO2Bg4caMXExFihXGf951Dr++GHH1rB7D0v663vabrEjtb9uuuuszp37mwdPHjQ5+UMs3zeRgYAAOAsjh6DBQAA4AsELAAAAJsRsAAAAGxGwAIAALAZAQsAAMBmBCwAAACbEbAAAABsRsACAACwGQELQEDRTaWrV6/ut+d/5ZVX5NFHH/XZ4+vGtIULF5Z//vnHZ88BwP9YyR1AlgkLC0v19m7dusnEiRPNxtLXXnutZLWjR49KhQoV5LfffpMyZcr47HkGDhwoZ8+elY8//thnzwHAvwhYALLMkSNHEr6fNWuWDBkyRHbs2JFwLHfu3JI/f34/lU7kjTfekGXLlsmCBQt8+jy///671KlTRw4dOiTXXHONT58LgH/QRQggyxQrVizhokFKW7SSHkvaRdi9e3dp166dCT9FixaVAgUKyPDhw+Xy5cvy3HPPScGCBaVEiRIyZcqURM+lXXAdOnQwAUZbw9q2bSt79+5NtXwzZ86UNm3aJDrWtGlTefrpp6V///7msbQMH374oURHR0uPHj0kX758Uq5cOZk/f37CfU6dOiWdO3c2XYEaGrVVbOrUqQm3V6lSxdR3zpw5NvxUAQQiAhaAgLd48WLT2rN8+XIZN26cCWH33nuvCTy//PKL9OnTx1wOHDhgzo+JiZHbb79d8ubNa+6zcuVK8/1dd90lsbGxHp9DQ9Eff/whtWvXTnbb9OnTpVChQrJu3ToTth5//HF58MEHpUGDBrJp0yZp2bKldOnSxTyvaxzXtm3bTOjavn27TJ482dzfnbZgrVixwic/LwD+R8ACEPC0lWr8+PFy4403yiOPPGK+aph58cUXTevQ4MGDJSIiQlatWpXQEpUtWzYzxklbiypVqmRakPbv3y9Lly71+Bz79u0THTFRvHjxZLdVq1ZNXn755YTn0lYpDUy9e/c2x7Sr8+TJk2bsltLnqVGjhglrOparWbNm0rp160SPef3116fZogYgeOXwdwEAIC2VK1c2gclFu+luueWWhOvZs2c33YA6Q09t3LhR/v77b9N95+7ixYuya9cuj89x4cIF8zVXrlzJbqtatWqy59Lg5l4e5Xp+beFq3769ad1q0aKF6eLU1i53GtJcLV4AQg8BC0DACw8PT3Rdx255OnblyhXzvX6tVauWfP7558keS8dFeeLqwtOuwqTnpPX8rtmRrudv1aqVaRGbN2+e/PTTT3LnnXfKk08+KW+99VbCff79998UywIg+NFFCCDk1KxZU/766y8pUqSIlC9fPtElpVmKOlA9KirKjJ2yg4YnHaD/2WefyTvvvGMGxrvT8V7ajQggNBGwAIQcncGnLVI6c1AHku/Zs8csv9CvXz85ePCgx/toF6SOldIB8ZmlY7K+/fZb0025detWmTt3rhkH5qJdg9qNqd2HAEITAQtAyImMjDSzB0uVKiX333+/CTc6OF7HWWkrVUp0BXcdIO/q6ssoHXCvg+F17Fbjxo3NuC19XBcNX1q2Ro0aZep5AAQuFhoFgP+nb4f16tUza1517NjRZ8+jSzToc3Tq1MlnzwHAv2jBAgC3weo6VkoXMfUVnWn4wAMP+DTAAfA/WrAAAABsRgsWAACAzQhYAAAANiNgAQAA2IyABQAAYDMCFgAAgM0IWAAAADYjYAEAANiMgAUAAGAzAhYAAIDY6/8Am1f9jS/g8tgAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 700x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import jax.numpy as jnp\n",
+    "from jaxsnn.event.types import EventPropSpike\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "rng = random.PRNGKey(42)\n",
+    "\n",
+    "# Create input spikes\n",
+    "input_spikes = EventPropSpike(\n",
+    "    time=jnp.array([0.0, 1e-4, 2e-4, 4e-4, 6e-4, 7e-4]),\n",
+    "    idx=jnp.array([0, 2, 1, 1, 0, 2]),\n",
+    "    current=jnp.array([0.0, 0.0, 0.0, 0.0, 0.0]))\n",
+    "\n",
+    "# Apply the model\n",
+    "_, weight = init(rng, 1)\n",
+    "_, _, output, _ = apply(weight, input_spikes)\n",
+    "\n",
+    "# Plot spike times\n",
+    "is_input = output.idx < input_size  # Input neurons are indexed 0, 1 and 2\n",
+    "is_output = output.idx >= input_size  # Output neurons are indexed 3 and 4\n",
+    "\n",
+    "plt.figure(figsize=(7, 4))\n",
+    "plt.scatter(output.time[is_input]*1000, output.idx[is_input], marker='o',\n",
+    "            label='Input Spikes', s=100)\n",
+    "plt.scatter(output.time[is_output]*1000, output.idx[is_output], marker='^',\n",
+    "            label='Output Spikes', s=100)\n",
+    "plt.title(\"Spike Times\")\n",
+    "plt.xlabel(\"Time (ms)\")\n",
+    "plt.ylabel(\"Neuron Index\")\n",
+    "plt.ylim(-0.5, 4.5)  # Adjust x-axis limits based on t_max\n",
+    "plt.grid()\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "visionary-dls",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/source/support.md
+++ b/docs/source/support.md
@@ -1,8 +1,8 @@
 # Supported simulators and hardware
 
-**NIR is currently supported by 7 simulators and 4 hardware platforms**, allowing users to seamlessly move between any of these platforms.
-The 7 simulators include Lava-DL, Nengo, Norse, Rockpool, Sinabs, snnTorch, and Spyx.
-The 4 hardware platforms include Intel Loihi (via Lava-DL), Xylo, Speck, and SpiNNaker2.
+**NIR is currently supported by 8 simulators and 5 hardware platforms**, allowing users to seamlessly move between any of these platforms.
+The 8 simulators include jaxsnn, Lava-DL, Nengo, Norse, Rockpool, Sinabs, snnTorch, and Spyx.
+The 5 hardware platforms include BrainScaleS-2, Intel Loihi (via Lava-DL), Speck, SpiNNaker2, and Xylo.
 
 The table below shows the integration progress for the respective frameworks.
 By "reading" a NIR graph, we mean converting it into a platform-specific representation.
@@ -10,6 +10,7 @@ By "reading" a NIR graph, we mean converting it into a platform-specific represe
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
+| [jaxsnn](https://github.com/electronic-visions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
 | [Lava-DL](https://github.com/lava-nc/lava-dl) | ✓ | ⬚ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
 | [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
 | [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |

--- a/docs/source/supported_primitives.py
+++ b/docs/source/supported_primitives.py
@@ -1,0 +1,79 @@
+import requests
+from nir.ir import __all_ir as primitives
+
+
+# Delete Input, Output, and NIRGraph from the list of primitives
+primitives = [p for p in primitives if p not in ["Input", "Output", "NIRGraph"]]
+
+# Fetch raw converter file from GitHub
+GITHUB_RAW_URLS = [
+    # (LibraryName, Direction, URL)
+    ("jaxsnn", "from_nir", "https://raw.githubusercontent.com/electronicvisions/jaxsnn/refs/heads/main/src/pyjaxsnn/jaxsnn/event/from_nir.py"),
+    ("Norse", "from_nir", "https://raw.githubusercontent.com/norse/norse/main/norse/torch/utils/import_nir.py"),
+    ("Norse", "to_nir", "https://raw.githubusercontent.com/norse/norse/main/norse/torch/utils/export_nir.py"),
+    ("rockpool", "from_nir", "https://raw.githubusercontent.com/synsense/rockpool/refs/heads/develop/rockpool/nn/modules/torch/nir.py"),
+    ("rockpool", "to_nir", "https://raw.githubusercontent.com/synsense/rockpool/refs/heads/develop/rockpool/nn/modules/torch/nir.py"),
+    ("sinabs", "from_nir", "https://github.com/synsense/sinabs/blob/develop/sinabs/nir.py"),
+    ("sinabs", "to_nir", "https://github.com/synsense/sinabs/blob/develop/sinabs/nir.py"),
+    ("snntorch", "from_nir", "https://raw.githubusercontent.com/jeshraghian/snntorch/refs/heads/master/snntorch/import_nir.py"),
+    ("snntorch", "to_nir", "https://raw.githubusercontent.com/jeshraghian/snntorch/refs/heads/master/snntorch/export_nir.py"),
+    ("SpiNNaker2", "from_nir", "https://gitlab.com/spinnaker2/py-spinnaker2/-/raw/main/src/spinnaker2/s2_nir.py?ref_type=heads"),
+    ("Spyx", "from_nir", "https://raw.githubusercontent.com/kmheckel/spyx/refs/heads/main/spyx/nir.py"),
+    ("Spyx", "to_nir", "https://raw.githubusercontent.com/kmheckel/spyx/refs/heads/main/spyx/nir.py"),
+]
+
+converter_contents = {}
+for lib_name, direction, url in GITHUB_RAW_URLS:
+    key = f"{lib_name}_{direction}"
+    try:
+        converter_contents[key] = requests.get(url).text
+    except Exception as e:
+        converter_contents[key] = ""
+        print(f"Failed to fetch {url}: {e}")
+
+# Check which primitives are supported in each library/direction
+supported = {}
+for name in primitives:
+    supported[name] = {}
+    for lib_name, _, _ in GITHUB_RAW_URLS:
+        from_key = f"{lib_name}_from_nir"
+        to_key = f"{lib_name}_to_nir"
+        from_supported = "ir.{})".format(name) in converter_contents.get(from_key, "") or "ir.{}(".format(name) in converter_contents.get(from_key, "") or "ir.{}:".format(name) in converter_contents.get(from_key, "")
+        to_supported = "ir.{})".format(name) in converter_contents.get(to_key, "") or "ir.{}(".format(name) in converter_contents.get(to_key, "") or "ir.{}:".format(name) in converter_contents.get(to_key, "")
+        if from_supported and to_supported:
+            supported[name][lib_name] = "⟷"
+        elif from_supported:
+            supported[name][lib_name] = "→"
+        elif to_supported:
+            supported[name][lib_name] = "←"
+        else:
+            supported[name][lib_name] = ""
+
+# Generate markdown table
+libs = []
+for lib, _, _ in GITHUB_RAW_URLS:
+    if lib not in libs:
+        libs.append(lib)
+header = "| Primitive | " + " | ".join(libs) + " |"
+separator = "|-----------|" + "|".join([":-----:" for _ in libs]) + "|"
+rows = []
+for name in primitives:
+    row = f"| {name} | " + " | ".join([supported[name][lib] for lib in libs]) + " |"
+    rows.append(row)
+dynamic_md = "\n".join([header, separator] + rows)
+
+static_md = """
+# Supported Primitives in NIR
+This document lists which primitives are supported by the software frameworks for conversion to and from NIR:
+- `→`: Supported for conversion from NIR
+- `←`: Supported for conversion to NIR
+- `⟷`: Supported for both conversion directions (to and from NIR)
+<br />
+"""
+
+full_md = static_md + "\n\n" + dynamic_md
+
+# 6. Save to file
+with open("supported_nodes.md", "w", encoding="utf-8") as f:
+    f.write(full_md)
+


### PR DESCRIPTION
### Motivation
With this addition, I aim to improve the NIR documentation by clearly indicating which NIRNodes are supported by which software frameworks. This has two key benefits:

1. Developers can easily see which Nodes are already supported in other frameworks, helping them identify which ones might be valuable to support in their own projects.
2. Users can quickly find out which frameworks support the Nodes they need, without having to dig through GitHub repositories to gather this information manually.

### State of the PR

First of all, this is just a draft. There are still some issues (see below) and I'm hoping to get feedback on it.
The main idea is that I didn't want to manually update this list every few months whenever a framework starts supporting a new NIRNode. So I thought it would be useful to make this process dynamic.
To achieve that, I manually specify the URLs of all the `from_nir.py` and `to_nir.py` fiels and lable them accordingly. 
The hackiest part is probably the detection logic: I search these files for `"ir.{node}:"`, `"ir.{node}("`, or `"ir.{node})"` for each `node` in a list of existing NIRNodes. (I can't omit the :, (, ) because otherwise, `nir.IF` will also be detected as `nir.I`)
This information is then formatted in a table
But yeah, while this mostly works, there are some problems with the current implementation.

### Issues

1. There are frameworks which to not have two distinct files for both directions of the NIR conversion. These are rockpool, sinabs and Spyx. I'm not sure how to handle this. Maybe the query can split the file in a from NIR and to NIR part. 
2. Frameworks (like jaxsnn and Spyx) mention NIRNodes in the conversion which they do not support. I will address this for jaxsnn but actually it is no problem to mention these nodes there. Only my way of creating this table does not work with it.
3. Finally I am not sure if there is a much easier way then just searching through the files. Or does it even make sense to do the whole thing automatically?

I would really like to hear some thoughts on this. :)

(This also depends on #158)