### PR TITLE
fix: URLs to jaxsnn and BrainScaleS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See our [example section](https://neuroir.org/docs/examples) for how to use NIR 
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
-| [jaxsnn](https://github.com/electronic-visions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
+| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
 | [Lava-DL](https://github.com/lava-nc/lava-dl) | ✓ | ⬚ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
 | [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
 | [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |

--- a/docs/source/examples/jaxsnn/nir-conversion.ipynb
+++ b/docs/source/examples/jaxsnn/nir-conversion.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "source": [
     "Note that here, the `apply` function performs the forward pass as well as the backward pass (pure simulator).\n",
-    "It is also possible to perform the forward pass externally, e.g. on a [BrainScaleS-2](https://open-neuromorphic.org/neuromorphic-computing/hardware/brainscales-2-universitat-heidelberg/) chip or other neuromorphic hardware and use jaxsnn only for gradient computation on the external spike times. This needs to be specified by the `external` argument in the `ConversionConfig` object."
+    "It is also possible to perform the forward pass externally, e.g. on a [BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/) chip or other neuromorphic hardware and use jaxsnn only for gradient computation on the external spike times. This needs to be specified by the `external` argument in the `ConversionConfig` object."
    ]
   },
   {

--- a/docs/source/support.md
+++ b/docs/source/support.md
@@ -10,7 +10,7 @@ By "reading" a NIR graph, we mean converting it into a platform-specific represe
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
-| [jaxsnn](https://github.com/electronic-visions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
+| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
 | [Lava-DL](https://github.com/lava-nc/lava-dl) | ✓ | ⬚ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
 | [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
 | [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |


### PR DESCRIPTION
I noticed that some of the URLs in the newly added mentions of jaxsnn were incorrect. I've fixed them now.