### PR TITLE
raise exception when user tries to create neurons with scalar parameters

### DIFF
--- a/nir/ir/neuron.py
+++ b/nir/ir/neuron.py
@@ -43,6 +43,9 @@ class CubaLI(NIRNode):
             == self.r.shape
             == self.v_leak.shape
         ), "All parameters must have the same shape"
+        assert (
+            len(self.tau_syn.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         # If w_in is a scalar, make it an array of same shape as v_leak
         self.w_in = np.ones_like(self.v_leak) * self.w_in
         self.input_type = {"input": np.array(self.v_leak.shape)}
@@ -104,6 +107,9 @@ class CubaLIF(NIRNode):
             == self.v_reset.shape
             == self.v_threshold.shape
         ), "All parameters must have the same shape"
+        assert (
+            len(self.tau_syn.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         # If w_in is a scalar, make it an array of same shape as v_threshold
         self.w_in = np.ones_like(self.v_threshold) * self.w_in
         self.input_type = {"input": np.array(self.v_threshold.shape)}
@@ -132,6 +138,9 @@ class I(NIRNode):  # noqa: E742
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
+        assert (
+            len(self.r.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         self.input_type = {"input": np.array(self.r.shape)}
         self.output_type = {"output": np.array(self.r.shape)}
 
@@ -169,6 +178,9 @@ class IF(NIRNode):
         assert (
             self.r.shape == self.v_threshold.shape == self.v_reset.shape
         ), "All parameters must have the same shape"
+        assert (
+            len(self.r.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         self.input_type = {"input": np.array(self.r.shape)}
         self.output_type = {"output": np.array(self.r.shape)}
 
@@ -204,6 +216,9 @@ class LI(NIRNode):
         assert (
             self.tau.shape == self.r.shape == self.v_leak.shape
         ), "All parameters must have the same shape"
+        assert (
+            len(self.tau.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         self.input_type = {"input": np.array(self.r.shape)}
         self.output_type = {"output": np.array(self.r.shape)}
 
@@ -255,6 +270,9 @@ class LIF(NIRNode):
             == self.v_reset.shape
             == self.v_threshold.shape
         ), "All parameters must have the same shape"
+        assert (
+            len(self.tau.shape) != 0
+        ), "Neuron parameters cannot be scalar, only numpy arrays"
         self.input_type = {"input": np.array(self.r.shape)}
         self.output_type = {"output": np.array(self.r.shape)}
 


### PR DESCRIPTION
I am proposing this as an alternative to #157. The user should get a useful error message instead of a cryptic error message inside type inference.

Not sure about the exact wording for the error message? Is CubaLIF technically (just) a neuron?