### PR TITLE
Improved LAVA <> NIR interface 

### DIFF
--- a/paper/lava_to_nir.py
+++ b/paper/lava_to_nir.py
@@ -1,0 +1,274 @@
+import typing
+import h5py
+import re
+import pathlib
+import nir
+import numpy as np
+import logging
+from typing import Tuple
+import collections.abc
+
+
+PATH_TYPE = typing.Union[str, pathlib.Path]
+
+
+def read_cuba_lif(layer: h5py.Group, shape: Tuple[int] = None) -> nir.NIRNode:
+    """Reads a CUBA LIF layer from a h5py.Group.
+    TODOs: 
+    - what if the layer is more than 1D?
+    - handle scaleRho tauRho theta
+    - support graded spikes
+    - support refdelay
+    - support other neuron types
+    If the neuron model is not supported, a warning is logged and None is returned.
+    """
+    logging.debug(f"read_cuba_lif {layer['neuron']['type'][()]}")
+
+    if 'gradedSpike' in layer['neuron']:
+        if layer['neuron']['gradedSpike'][()]:
+            logging.warning('graded spikes not supported')
+
+    if layer['neuron']['type'][()] in [b'LOIHI', b'CUBA']:
+        if layer['neuron']['refDelay'][()] != 1:
+            logging.warning('refdelay not supported, setting to 1')
+        if layer['neuron']['vDecay'] == 0:
+            logging.warning('vDecay is 0, setting to inf')
+        if layer['neuron']['iDecay'] == 0:
+            logging.warning('iDecay is 0, setting to inf')
+
+        # Lava-dl exports hardware fixed tipe to hdf5. For NIR, export in floating point. 
+        dt      = 1e-4  # This dt value is according to nir_to_lava.py script. https://github.com/neuromorphs/NIR/blob/main/paper/nir_to_lava.py#L67
+        vdecay  = layer['neuron']['vDecay'][()]  / 4096 # Save the value in NIR as floating point
+        idecay  = layer['neuron']['iDecay'][()]  / 4096 # Save the value in NIR as floating point
+        thr     = layer['neuron']['vThMant'][()] / 64   # Save the value in NIR as floating point
+        tau_mem = dt/float(vdecay) if vdecay != 0 else np.inf
+        tau_syn = dt/float(idecay) if idecay != 0 else np.inf
+        shape   = layer['weight'].shape[0]
+        r       = tau_mem/dt # no scaling of synaptic current
+        w_in    = tau_syn/dt # no scaling of synaptic voltage
+
+        return nir.CubaLIF(
+            tau_syn=np.full(shape, tau_syn),
+            tau_mem=np.full(shape, tau_mem),
+            r=np.full(shape, r),  
+            v_leak=np.full(shape, 0.),  # currently no bias in Loihi's neurons
+            v_threshold=np.full(shape, thr),
+            w_in=np.full(shape,w_in),  
+            v_reset=np.full(shape,0.) # LAVA-DL CUBA LiF always reset to 0
+        )
+    else:
+        logging.warning('currently only support for CUBA-LIF')
+        logging.error(f"no support for {layer['neuron']['type'][()]}")
+        return None
+
+
+def read_node(network: h5py.Group) -> nir.NIRNode:
+    """Read a graph from a HDF/conn5 file.
+    
+    TODOs:
+    - support delay in convolutional layers
+    """
+    nodes = []
+    edges = []
+    current_shape = None
+
+    # need to sort keys as integers, otherwise does 1->10->2
+    layer_keys = sorted(list(map(int, network.keys())))
+
+    # iterate over layers
+    for layer_idx_int in layer_keys:
+        layer_idx = str(layer_idx_int)
+        layer = network[layer_idx]
+
+        logging.info(f"--- Layer #{layer_idx}: {layer['type'][0].decode().upper()}")
+        logging.debug(f'current shape: {current_shape}')
+
+        if layer['type'][0] == b'dense':
+            # shape, type, neuron, inFeatures, outFeatures, weight, delay?
+            logging.debug(f'dense weights of shape {layer["weight"][:].shape}')
+
+            # make sure weight matrix matches shape of previous layer
+            if current_shape is None:
+                assert len(layer['weight'][:].shape) == 2, 'shape mismatch in dense'
+                current_shape = layer['weight'][:].shape[1]
+            elif isinstance(current_shape, int):
+                assert current_shape == layer['weight'][:].shape[-1], 'shape mismatch in dense'
+            else:
+                assert len(current_shape) == 1, 'shape mismatch in dense'
+                assert current_shape[0] == layer['weight'][:].shape[1], 'shape mismatch in dense'
+
+            # infer shape of current layer
+            assert len(layer['weight'][:].shape) in [1, 2], 'invalid dimension for dense layer'
+            current_shape = 1 if len(layer['weight'][:].shape) == 1 else layer['weight'][:].shape[0]
+
+            # store the weight matrix (np.array, carrying over type)
+            if 'bias' in layer:
+                nodes.append(nir.Affine(weight=(layer['weight'][:] / 64), bias=layer['bias'][:]))
+            else:
+                nodes.append(nir.Linear(weight=(layer['weight'][:] / 64))) # Save weights as floating point as well.
+
+            # store the neuron group
+            neuron = read_cuba_lif(layer)
+            if neuron is None:
+                raise NotImplementedError('could not read neuron')
+            nodes.append(neuron)
+
+            # connect linear to neuron, neuron to next element
+            edges.append((len(nodes)-2, len(nodes)-1))
+            edges.append((len(nodes)-1, len(nodes)))
+
+        elif layer['type'][0] == b'input':
+            # iDecay, refDelay, scaleRho, tauRho, theta, type, vDecay, vThMant, wgtExp
+            current_shape = layer['shape'][:]
+            logging.warning('INPUT - not implemented yet')
+            logging.debug(f'keys: {layer.keys()}')
+            logging.debug(f'shape: {layer["shape"][:]}, bias: {layer["bias"][()]}, weight: {layer["weight"][()]}')
+            logging.debug(f'neuron keys: {", ".join(list(layer["neuron"].keys()))}')
+
+        elif layer['type'][0] == b'flatten':
+            # shape, type
+            logging.debug(f"flattening shape (ignored): {layer['shape'][:]}")
+            # check last layer's size
+            assert len(nodes) > 0, 'flatten layer: must be preceded by a layer'
+            assert isinstance(current_shape, tuple), 'flatten layer: nothing to flatten'
+            last_node = nodes[-1]
+            nodes.append(nir.Flatten(n_dims=1))
+            current_shape = int(np.prod(current_shape))
+            edges.append((len(nodes)-1, len(nodes)))
+
+        elif layer['type'][0] == b'conv':
+            # shape, type, neuron, inChannels, outChannels, kernelSize, stride, 
+            # padding, dilation, groups, weight, delay?
+            weight = layer['weight'][:]
+            stride = layer['stride'][()]
+            pad = layer['padding'][()]
+            dil = layer['dilation'][()]
+            kernel_size = layer['kernelSize'][()]
+            in_channels = layer['inChannels'][()]
+            out_channels = layer['outChannels'][()]
+            logging.debug(f'stride {stride} padding {pad} dilation {dil} w {weight.shape}')
+
+            # infer shape of current layer
+            assert in_channels == current_shape[0], 'in_channels must match previous layer'
+            x_prev = current_shape[1]
+            y_prev = current_shape[2]
+            x = (x_prev + 2*pad[0] - dil[0]*(kernel_size[0]-1) - 1) // stride[0] + 1
+            y = (y_prev + 2*pad[1] - dil[1]*(kernel_size[1]-1) - 1) // stride[1] + 1
+            current_shape = (out_channels, x, y)
+
+            # check for unsupported options
+            if layer['groups'][()] != 1:
+                logging.warning('groups not supported, setting to 1')
+            if 'delay' in layer:
+                logging.warning(f"delay=({layer['delay'][()]}) not supported, ignoring")
+
+            # store the conv matrix (np.array, carrying over type)
+            nodes.append(nir.Conv2d(
+                weight=layer['weight'][:],
+                bias=layer['bias'][:] if 'bias' in layer else None,
+                stride=stride,
+                padding=pad,
+                dilation=dil,
+                groups=layer['groups'][()]
+            ))
+
+            # store the neuron group
+            neuron = read_cuba_lif(layer)
+            if neuron is None:
+                raise NotImplementedError('could not read neuron')
+            nodes.append(neuron)
+
+            # connect conv to neuron group, neuron group to next element
+            edges.append((len(nodes)-2, len(nodes)-1))
+            edges.append((len(nodes)-1, len(nodes)))
+
+        elif layer['type'][0] == b'average':
+            # shape, type
+            logging.error('AVERAGE LAYER - not implemented yet')
+            raise NotImplementedError('average layer not implemented yet')
+
+        elif layer['type'][0] == b'concat':
+            # shape, type, layers
+            logging.error('CONCAT LAYER - not implemented yet')
+            raise NotImplementedError('concat layer not implemented yet')
+
+        elif layer['type'][0] == b'pool':
+            # shape, type, neuron, kernelSize, stride, padding, dilation, weight
+            logging.error('POOL LAYER - not implemented yet')
+            raise NotImplementedError('pool layer not implemented yet')
+
+        else:
+            logging.error('layer type not supported:', layer['type'][0])
+
+    # remove last edge (no next element)
+    edges.pop(-1)
+
+    return nir.NIRGraph(nodes={i: node for i, node in enumerate(nodes)}, edges=edges)
+
+
+def convert_to_nir(net_config: PATH_TYPE, path: PATH_TYPE) -> nir.NIRGraph:
+    """Load a NIR from a HDF/conn5 file."""
+    with h5py.File(net_config, "r") as f:
+        nir_graph = read_node(f["layer"])
+    #nir_graph.input_type['input'] = nir_graph.input_type.pop('input_0')
+    nir_graph = normalize_nir_graph(nir_graph, to_bytes_in_edges=True)
+    #nir_graph.check_types()
+    nir_graph.edges[3]=(b'input',0)
+    nir_graph.edges[4]=(3,b'output')
+    nir.write(path, nir_graph)
+
+
+class Network:
+    def __init__(self, path: typing.Union[str, pathlib.Path]) -> None:
+        nir_graph = nir.read(path)
+        self.graph = nir_graph
+        # TODO: implement the NIR -> Lava conversion
+        pass
+
+def normalize_nir_graph(obj, to_bytes_in_edges=False, _in_edges=False):
+    """
+    Recursively normalize all 'input_#'/'output_#' to 'input'/'output'.
+    Only convert 'input'/'output' to bytes inside the 'edges' field if to_bytes_in_edges is True.
+    """
+    def norm(x, in_edges):
+        # Normalize input/output with optional _#
+        if isinstance(x, str):
+            if re.match(r'^input(_\d+)?$', x):
+                return b'input' if (to_bytes_in_edges and in_edges) else 'input'
+            if re.match(r'^output(_\d+)?$', x):
+                return b'output' if (to_bytes_in_edges and in_edges) else 'output'
+            return x
+        if isinstance(x, bytes):
+            try:
+                x_str = x.decode()
+            except Exception:
+                return x
+            if re.match(r'^input(_\d+)?$', x_str):
+                return b'input' if (to_bytes_in_edges and in_edges) else 'input'
+            if re.match(r'^output(_\d+)?$', x_str):
+                return b'output' if (to_bytes_in_edges and in_edges) else 'output'
+            return x
+        return x
+
+    if isinstance(obj, dict):
+        new_dict = {}
+        for k, v in obj.items():
+            if k == 'edges' and isinstance(v, list):
+                # Recursively process everything inside edges
+                new_dict[k] = normalize_nir_graph(v, to_bytes_in_edges, _in_edges=True)
+            else:
+                new_dict[norm(k, _in_edges)] = normalize_nir_graph(v, to_bytes_in_edges, _in_edges)
+        return new_dict
+    if isinstance(obj, list):
+        return [normalize_nir_graph(v, to_bytes_in_edges, _in_edges) for v in obj]
+    if isinstance(obj, tuple):
+        return tuple(normalize_nir_graph(v, to_bytes_in_edges, _in_edges) for v in obj)
+    if isinstance(obj, set):
+        return {normalize_nir_graph(v, to_bytes_in_edges, _in_edges) for v in obj}
+    if isinstance(obj, np.ndarray) and obj.dtype.kind == 'U':
+        return obj
+    if hasattr(obj, '__dict__'):
+        for k, v in vars(obj).items():
+            setattr(obj, k, normalize_nir_graph(v, to_bytes_in_edges, _in_edges))
+        return obj
+    return norm(obj, _in_edges)

--- a/paper/nir_to_lava.py
+++ b/paper/nir_to_lava.py
@@ -1,3 +1,5 @@
+# Document from the official NIR repository: https://github.com/neuromorphs/NIR/blob/main/paper/nir_to_lava.py#L67
+# Modifications made by Alex G. Gener for dynamic neuron allocation. See line 408
 """
 Sharp edges:
 - in lava-dl, the current and voltage state is not automatically reset. must do this manually after every forward pass.
@@ -8,12 +10,6 @@ import numpy as np
 from dataclasses import dataclass
 from functools import partial
 from enum import Enum
-
-# from lava.proc.embedded_io.spike import PyToNxAdapter, NxToPyAdapter
-# from lava.proc.monitor.process import Monitor
-# from lava.magma.core.run_conditions import RunSteps
-# from lava.proc.io.source import RingBuffer
-# from lava.proc.io.sink import RingBuffer as Sink
 from lava.proc.lif.process import LIF
 from lava.proc.dense.process import Dense
 import lava.lib.dl.slayer as slayer
@@ -399,17 +395,16 @@ def _nir_node_to_lava_dl(node: nir.NIRNode, import_config: ImportConfig):
         )
         dense.weight = torch.nn.Parameter(
             data=torch.from_numpy(node.weight.reshape(dense.weight.shape)), 
-            requires_grad=True
         )
         dense.bias = torch.nn.Parameter(
-            data=torch.zeros_like((node.weight.shape[0],)),
+            data=torch.zeros((node.weight.shape[0],)),
             requires_grad=False
         )
         return dense
 
     elif isinstance(node, nir.CubaLIF):
         # TODO: figure out how to make the n_neurons dynamic
-        n_neurons = 7
+        n_neurons = int(node.input_type['input'][0])
 
         # bias = node.v_leak * dt / node.tau_mem
 


### PR DESCRIPTION
Created from the pull request in lava-dl [lava_to_nir](https://github.com/lava-nc/lava-dl/pull/218/files#diff-b8d114c7398f12e3826411a8227dd0466dbf0f41b14dfdcc8e50db0adc4c6676) and the official documentation of NIR and the [lava_to_nir](https://github.com/neuromorphs/NIR/blob/main/paper/nir_to_lava.py#L67) python script.

Modified two lib scripts `lava_to_nir.py` and `nir_to_lava.py` that have been tested for the [Oxford example in lava-dl](https://lava-nc.org/lava-lib-dl/slayer/notebooks/oxford/train.html) 

For testing purposes, use the oxford_training and its data in [Oxford example in lava-dl](https://lava-nc.org/lava-lib-dl/slayer/notebooks/oxford/train.html) 

 ## Main modifications `lava_to_nir.py`

 1. Lava-dl only uses one size parameters for all neurons. Exported to NIR as numpy arrays with N data according to number of neurons per layer
2. Saving floating point parameters of CUBA LiF neurons in NIR instead of hardware fixed point values.
3. Added dt value when exporting from LAVA-dl to NIR.

## Main modifications `nir_to_lava.py`
 1. Introduced dynamic n_neurons per layer.

## Main limitations

1. Considering `dt=1e-4` according to `nir_to_lava.py` script. Need to check this with LAVA developers.

2. Tested only 1D Dense CUBA LiF Neurons. According to the code, there is more work to do for 2D Dense layers. 

3. Didn't test different Neurons. 

## CUBA LiF. LAVA to NIR

Here it is a small piece of code that represents the matching of different values from LAVA-dl to NIR. Double check if this is correct with NIR developers. 

```
# Lava-dl exports hardware fixed tipe to hdf5. For NIR, export in floating point. 
        dt      = 1e-4  # This dt value is according to nir_to_lava.py script. https://github.com/neuromorphs/NIR/blob/main/paper/nir_to_lava.py#L67
        vdecay  = layer['neuron']['vDecay'][()]  / 4096 # Save the value in NIR as floating point
        idecay  = layer['neuron']['iDecay'][()]  / 4096 # Save the value in NIR as floating point
        thr     = layer['neuron']['vThMant'][()] / 64   # Save the value in NIR as floating point
        tau_mem = dt/float(vdecay) if vdecay != 0 else np.inf
        tau_syn = dt/float(idecay) if idecay != 0 else np.inf
        shape   = layer['weight'].shape[0]
        r       = tau_mem/dt # no scaling of synaptic current
        w_in    = tau_syn/dt # no scaling of synaptic voltage

```