### PR TITLE
Adds an option to omit the type checking when reading a NIR graph

### DIFF
--- a/nir/serialization.py
+++ b/nir/serialization.py
@@ -173,7 +173,7 @@ def hdf2dict(node: Any) -> Dict[str, Any]:
     return ret
 
 
-def read(filename: Union[str, pathlib.Path]) -> nir.NIRGraph:
+def read(filename: Union[str, pathlib.Path], type_check: bool = True) -> nir.NIRGraph:
     """Load a NIR from a HDF/conn5 file.
     Attempts to read a NIRGraph from a file and pass in the key-value parameters to the
     corresponding NIR nodes.
@@ -181,12 +181,18 @@ def read(filename: Union[str, pathlib.Path]) -> nir.NIRGraph:
 
     Arguments:
         filename (Union[str, Path]): The filename as either a string or pathlib Path.
+        type_check (bool): Whether to type check the graph and verify that all input types align with output types
+                for every node in the graph. May break the loading for older graphs. Defaults to True.
 
     Returns:
         A NIRGraph read from the file.
     """
     with h5py.File(filename, "r") as f:
         data_dict = hdf2dict(f["node"])
+        if hasattr(data_dict, "type_check"):
+            raise ValueError("The 'type_check' key was found in the read NIR graph, but is unsupported and clashes with the type checking parameter in the read function")
+        else:
+            data_dict["type_check"] = type_check
         return nir.dict2NIRNode(data_dict)
 
 

--- a/tests/test_readwrite.py
+++ b/tests/test_readwrite.py
@@ -313,3 +313,10 @@ def test_deserialize():
         except Exception as e:
             print(f"Failed to read {file}: {e}")
             raise e
+
+def test_read_without_type_check():
+    # Fails due to type mismatches
+    with pytest.raises(ValueError):
+        nir.NIRGraph.from_list(nir.Linear(weight=np.zeros((2, 2))), nir.Linear(weight=np.zeros((1, 1))), type_check=True)
+    # Works
+    nir.NIRGraph.from_list(nir.Linear(weight=np.zeros((2, 2))), nir.Linear(weight=np.zeros((1, 1))), type_check=False)


### PR DESCRIPTION
Adds a `type_check: bool` option to `nir.read`