### PR TITLE
Fix GitHub Actions workflow for supported primitives

### DIFF
--- a/.github/workflows/update_supported_primitives.yml
+++ b/.github/workflows/update_supported_primitives.yml
@@ -32,4 +32,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add docs/**/supported_primitives.md
           git commit -m "chore: weekly supported primitives update" || echo "No changes to commit"
-          git push
+          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+            git push origin HEAD:main
+          fi


### PR DESCRIPTION
The workflow for generating the supported nodes .md files failed due to an incorrect path.
It will now also run for every pull request to prevent such issues in the future.
But when triggered through a PR, the `git push` won't be executed. If this is not disabled, PRs may later receive an unrelated update-supported-primitives commit.