### PR TITLE
fix: Example for snntorch

### DIFF
--- a/docs/source/examples/snntorch/nir-conversion.ipynb
+++ b/docs/source/examples/snntorch/nir-conversion.ipynb
@@ -28,7 +28,7 @@
    },
    "outputs": [],
    "source": [
-    "import snntorch as snn\n",
+    "from snntorch.import_nir import import_from_nir\n",
     "import torch\n",
     "\n",
     "import nir\n",
@@ -39,17 +39,22 @@
     "li_tau = torch.tensor([0.9, 0.8])\n",
     "li_r = torch.tensor([1.0, 1.0])\n",
     "li_v_leak = torch.tensor([0.0, 0.0])\n",
-    "nir_network = nir.NIRGraph.from_list(nir.Affine(affine_weights, affine_bias), nir.LI(li_tau, li_r, li_v_leak))\n",
+    "li_v_thr = torch.tensor([1.0, 1.0])\n",
+    "li_v_reset = torch.tensor([0.0, 0.0])\n",
+    "nir_network = nir.NIRGraph.from_list(\n",
+    "    nir.Affine(affine_weights, affine_bias),\n",
+    "    nir.LIF(li_tau, li_r, li_v_leak, li_v_thr, li_v_reset)\n",
+    ")\n",
     "\n",
     "# Import to snnTorch\n",
-    "snntorch_network = snn.import_from_nir(nir_network)"
+    "snntorch_network = import_from_nir(nir_network)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Export a NIR graph from snnTorch"
+    "## Export a NIR graph from snnTorch"
    ]
   },
   {
@@ -62,7 +67,9 @@
    },
    "outputs": [],
    "source": [
+    "import nir\n",
     "import snntorch as snn\n",
+    "from snntorch.export_nir import export_to_nir\n",
     "import torch\n",
     "\n",
     "lif1 = snn.Leaky(beta=0.9, init_hidden=True)\n",
@@ -80,7 +87,7 @@
     "sample_data = torch.randn(1, 784)\n",
     "\n",
     "# Export to nir\n",
-    "nir_model = snn.export_to_nir(snntorch_network, sample_data)\n",
+    "nir_model = export_to_nir(snntorch_network, sample_data)\n",
     "\n",
     "# Save to file\n",
     "nir.write(\"nir_model.nir\", nir_model)"


### PR DESCRIPTION
This fixes the snntorch example since NIR is [not automatically imported anymore by snntorch](https://github.com/jeshraghian/snntorch/commit/05d4f377e1fc65967608879649d84b2eeff203f4).
