### PR TITLE
Permit optional v_reset values

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720110830,
-        "narHash": "sha256-E5dN9GDV4LwMEduhBLSkyEz51zM17XkWZ3/9luvNOPs=",
+        "lastModified": 1761468971,
+        "narHash": "sha256-vY2OLVg5ZTobdroQKQQSipSIkHlxOTrIF1fsMzPh8w8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0d0be00d4ecc4b51d2d6948e37466194c1e6c51",
+        "rev": "78e34d1667d32d8a0ffc3eba4591ff256e80576e",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Neuromorphic Intermediate Representation reference implementation"; 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.05";
+    nixpkgs.url = "nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils }:

--- a/nir/ir/neuron.py
+++ b/nir/ir/neuron.py
@@ -89,13 +89,15 @@ class CubaLIF(NIRNode):
     r: np.ndarray  # Resistance
     v_leak: np.ndarray  # Leak voltage
     v_threshold: np.ndarray  # Firing threshold
-    v_reset: np.ndarray  # Reset potential
+    v_reset: Optional[np.ndarray] = None  # Reset potential
     w_in: np.ndarray = 1.0  # Input current weight
     input_type: Optional[Dict[str, np.ndarray]] = None
     output_type: Optional[Dict[str, np.ndarray]] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
+        if self.v_reset is None:
+            self.v_reset = np.zeros_like(self.v_threshold)
         assert (
             self.tau_syn.shape
             == self.tau_mem.shape
@@ -160,12 +162,14 @@ class IF(NIRNode):
 
     r: np.ndarray  # Resistance
     v_threshold: np.ndarray  # Firing threshold
-    v_reset: np.ndarray  # Reset potential
+    v_reset: Optional[np.ndarray] = None  # Reset potential
     input_type: Optional[Dict[str, np.ndarray]] = None
     output_type: Optional[Dict[str, np.ndarray]] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
+        if self.v_reset is None:
+            self.v_reset = np.zeros_like(self.v_threshold)
         assert (
             self.r.shape == self.v_threshold.shape == self.v_reset.shape
         ), "All parameters must have the same shape"
@@ -242,12 +246,14 @@ class LIF(NIRNode):
     r: np.ndarray  # Resistance
     v_leak: np.ndarray  # Leak voltage
     v_threshold: np.ndarray  # Firing threshold
-    v_reset: np.ndarray  # Reset potential
+    v_reset: Optional[np.ndarray] = None  # Reset potential
     input_type: Optional[Dict[str, np.ndarray]] = None
     output_type: Optional[Dict[str, np.ndarray]] = None
     metadata: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
+        if self.v_reset is None:
+            self.v_reset = np.zeros_like(self.v_threshold)
         assert (
             self.tau.shape
             == self.r.shape


### PR DESCRIPTION
So many frameworks are breaking because of the introduced `v_threshold` parameters. This PR permits Optional values and defaults to zeros (of similar shape to the other parameters).