### PR TITLE
fix: Permissions for auto-updating the documentation

### DIFF
--- a/.github/workflows/update_supported_primitives.yml
+++ b/.github/workflows/update_supported_primitives.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-md:
     runs-on: ubuntu-latest
@@ -30,8 +34,24 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
           git add docs/**/supported_primitives.md
-          git commit -m "chore: weekly supported primitives update" || echo "No changes to commit"
+          git commit -m "chore: weekly supported primitives update" || {
+            echo "No changes to commit"
+            exit 0
+          }
+          
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            git push origin HEAD:main
+            BRANCH="chore/weekly-supported-primitives"
+          
+            git checkout -B "$BRANCH"
+            git push origin "$BRANCH" --force
+          
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: Weekly supported primitives update" \
+              --body "Automated weekly update of documentation regarding the supported primitives." \
+              || echo "Pull request already exists"
           fi
+


### PR DESCRIPTION
The [latest run](https://github.com/neuromorphs/NIR/actions/runs/20703355061) of the GitHub Action for updating of the supported nodes failed due to missing permissions (It tried to push directly to the main branch). Since this is not allowed I would suggest to let the workflow create a PR which then can be verified and merged by a maintainer.

The alternative would be to give it the permission but I think verifying that the PR is sensible is generally a good thing.