### PR TITLE
fix(docs): Build and use correct URLs, link favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ NIR is a set of computational primitives, shared across different neuromorphic f
 
 NIR is useful when you want to move a model from one platform to another, for instance from a simulator to a hardware platform.
 
-> Read more about NIR in our [documentation about NIR primitives](https://neuroir.org/docs/primitives.html)
+> Read more about NIR in our [documentation about NIR primitives](https://neuroir.org/docs/primitives/)
 
-> See [which frameworks are currently supported by NIR](https://neuroir.org/docs/support.html).
+> See [which frameworks are currently supported by NIR](https://neuroir.org/docs/support/).
 
 ## Usage
 > Read more in our [documentation about NIR usage](https://neuroir.org/docs/usage) and see more examples in our [examples section](https://neuroir.org/docs/examples)
@@ -40,20 +40,20 @@ See our [example section](https://neuroir.org/docs/examples) for how to use NIR 
 Recently, NIR has been extended by an intermediate representation for data exchange in spiking neural networks: [NIRData](https://neuroir.org/docs/nirdata).
 
 ## Frameworks that currently support NIR
-> Read more in our [documentation about NIR support](https://neuroir.org/docs/support.html)
+> Read more in our [documentation about NIR support](https://neuroir.org/docs/support/)
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
-| [hxtorch](https://github.com/electronicvisions/hxtorch) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ✓ | ✓ | [hxtorch examples](https://neuroir.org/docs/examples/hxtorch/nir-conversion.html) |
-| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
-| [Lava-DL](https://github.com/lava-nc/lava-dl) | ⬚ | ✓ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
-| [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
-| [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |
-| [Rockpool](https://rockpool.ai) ([SynSense Xylo chip](https://www.synsense.ai/products/xylo/)) | ✓ | ✓ | [Rockpool/Xylo examples](https://neuroir.org/docs/examples/rockpool/nir-conversion.html)
-| [Sinabs](https://sinabs.readthedocs.io) ([SynSense Speck chip](https://www.synsense.ai/products/speck-2/)) | ✓ | ✓ | [Sinabs/Speck examples](https://neuroir.org/docs/examples/sinabs/nir-conversion.html) |
-| [snnTorch](https://github.com/jeshraghian/snntorch/) | ✓ | ✓ | [snnTorch examples](https://neuroir.org/docs/examples/snntorch/nir-conversion.html) |
-| [SpiNNaker2](https://spinncloud.com/portfolio/spinnaker2/) | ⬚ | ✓ | [SpiNNaker2 examples](https://neuroir.org/docs/examples/spinnaker2/import.html) |
-| [Spyx](https://github.com/kmheckel/spyx) | ✓ | ✓ | [Spyx examples](https://neuroir.org/docs/examples/spyx/conversion.html)
+| [hxtorch](https://github.com/electronicvisions/hxtorch) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ✓ | ✓ | [hxtorch examples](https://neuroir.org/docs/examples/hxtorch/nir-conversion/) |
+| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion/) |
+| [Lava-DL](https://github.com/lava-nc/lava-dl) | ⬚ | ✓ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion/) |
+| [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion/) |
+| [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion/) |
+| [Rockpool](https://rockpool.ai) ([SynSense Xylo chip](https://www.synsense.ai/products/xylo/)) | ✓ | ✓ | [Rockpool/Xylo examples](https://neuroir.org/docs/examples/rockpool/nir-conversion/)
+| [Sinabs](https://sinabs.readthedocs.io) ([SynSense Speck chip](https://www.synsense.ai/products/speck-2/)) | ✓ | ✓ | [Sinabs/Speck examples](https://neuroir.org/docs/examples/sinabs/nir-conversion/) |
+| [snnTorch](https://github.com/jeshraghian/snntorch/) | ✓ | ✓ | [snnTorch examples](https://neuroir.org/docs/examples/snntorch/nir-conversion/) |
+| [SpiNNaker2](https://spinncloud.com/portfolio/spinnaker2/) | ⬚ | ✓ | [SpiNNaker2 examples](https://neuroir.org/docs/examples/spinnaker2/import/) |
+| [Spyx](https://github.com/kmheckel/spyx) | ✓ | ✓ | [Spyx examples](https://neuroir.org/docs/examples/spyx/conversion/)
 
 
 ## Acknowledgements

--- a/docs/source/api_nirtorch.md
+++ b/docs/source/api_nirtorch.md
@@ -8,11 +8,11 @@ This page lists functions and classes exposed by the `nirtorch` package for conv
 - **Graph loading**: Convert NIR graph to PyTorch `nn.Module`
 
 For detailed usage examples and API documentation, see:
-- [PyTorch developer guide](dev_pytorch.ipynb)
+- [PyTorch developer guide](#dev_pytorch)
 - [nirtorch source code](https://github.com/neuromorphs/nirtorch/tree/main/nirtorch)
 
 ## Key Modules
 
 - **Tracing**: Extract computational graphs from PyTorch models - see [tracing guide](#nirtorch_tracing)
-- **Interpreting**: Load NIR graphs as PyTorch modules - see [interpreting guide](nirtorch/interpreting.ipynb)
-- **State management**: Handle stateful operations - see [state guide](nirtorch/state.md)
+- **Interpreting**: Load NIR graphs as PyTorch modules - see [interpreting guide](#nirtorch_interpreting)
+- **State management**: Handle stateful operations - see [state guide](#nirtorch_state)

--- a/docs/source/myst.yml
+++ b/docs/source/myst.yml
@@ -65,6 +65,8 @@ site:
   title: NIR documentation
 
   options:
+    favicon: ../neuroir.org/favicon.png
+    folders: true
     logo: ../logo_light.png
     logo_text: Neuromorphic Intermediate Representation (NIR)
     style: ./style.css

--- a/docs/source/nirtorch/interpreting.ipynb
+++ b/docs/source/nirtorch/interpreting.ipynb
@@ -2,10 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "label": "nirtorch_interpreting"
-   },
+   "metadata": {},
    "source": [
+    "(nirtorch_interpreting)=\n",
     "# To PyTorch: Interpreting NIR\n",
     "\n",
     "We rely on [`torch.fx`](https://pytorch.org/docs/stable/fx.html) to interpret NIR graphs.\n",

--- a/docs/source/nirtorch/state.md
+++ b/docs/source/nirtorch/state.md
@@ -120,7 +120,7 @@ def stateful_function(data, state):
     return output, new_state 
 ```
 
-Once NIRTorch has parsed a NIR module into Torch modules (read more about that in the page about [To PyTorch: Interpreting NIR](/nirtorch/interpreting.md)),
+Once NIRTorch has parsed a NIR module into Torch modules (read more about that in the page about [To PyTorch: Interpreting NIR](#nirtorch_interpreting)),
 the resulting module expects a second `state` parameter, like the function above.
 Similarly, it will return a tuple of `(data, state)`.
 Here is a full example where we first initialize a Torch module from NIRTorch, and then applies it several times with the correct state

--- a/docs/source/nirtorch/tracing.ipynb
+++ b/docs/source/nirtorch/tracing.ipynb
@@ -2,10 +2,9 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "label": "nirtorch_tracing"
-   },
+   "metadata": {},
    "source": [
+    "(nirtorch_tracing)=\n",
     "# To NIR: Tracing PyTorch\n",
     "\n",
     "When creating NIR nodes from PyTorch, we go through the PyTorch modules to create a graph structure that we can populate with NIR nodes.\n",

--- a/docs/source/support.md
+++ b/docs/source/support.md
@@ -10,16 +10,16 @@ By "reading" a NIR graph, we mean converting it into a platform-specific represe
 
 | **Framework** | **Write to NIR** | **Read from NIR** | **Examples** |
 | --------------- | :--: | :--: | :------: |
-| [hxtorch](https://github.com/electronicvisions/hxtorch) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ✓ | ✓ | [hxtorch examples](https://neuroir.org/docs/examples/hxtorch/nir-conversion.html) |
-| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion.html) |
-| [Lava-DL](https://github.com/lava-nc/lava-dl) | ⬚ | ✓ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion.html) |
-| [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion.html) |
-| [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion.html) |
-| [Rockpool](https://rockpool.ai) ([SynSense Xylo chip](https://www.synsense.ai/products/xylo/)) | ✓ | ✓ | [Rockpool/Xylo examples](https://neuroir.org/docs/examples/rockpool/nir-conversion.html)
-| [Sinabs](https://sinabs.readthedocs.io) ([SynSense Speck chip](https://www.synsense.ai/products/speck-2/)) | ✓ | ✓ | [Sinabs/Speck examples](https://neuroir.org/docs/examples/sinabs/nir-conversion.html) |
-| [snnTorch](https://github.com/jeshraghian/snntorch/) | ✓ | ✓ | [snnTorch examples](https://neuroir.org/docs/examples/snntorch/nir-conversion.html) |
-| [SpiNNaker2](https://spinncloud.com/portfolio/spinnaker2/) | ⬚ | ✓ | [SpiNNaker2 examples](https://neuroir.org/docs/examples/spinnaker2/import.html) |
-| [Spyx](https://github.com/kmheckel/spyx) | ✓ | ✓ | [Spyx examples](https://neuroir.org/docs/examples/spyx/conversion.html)
+| [hxtorch](https://github.com/electronicvisions/hxtorch) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ✓ | ✓ | [hxtorch examples](https://neuroir.org/docs/examples/hxtorch/nir-conversion/) |
+| [jaxsnn](https://github.com/electronicvisions/jaxsnn) ([BrainScaleS-2](https://wiki.ebrains.eu/bin/view/Collabs/neuromorphic/BrainScaleS/)) | ⬚ | ✓ | [jaxsnn examples](https://neuroir.org/docs/examples/jaxsnn/nir-conversion/) |
+| [Lava-DL](https://github.com/lava-nc/lava-dl) | ⬚ | ✓ | [Lava/Loihi examples](https://neuroir.org/docs/examples/lava/nir-conversion/) |
+| [Nengo](https://nengo.ai) | ✓ | ✓ | [Nengo examples](https://neuroir.org/docs/examples/nengo/nir-conversion/) |
+| [Norse](https://github.com/norse/norse) | ✓ | ✓ | [Norse examples](https://neuroir.org/docs/examples/norse/nir-conversion/) |
+| [Rockpool](https://rockpool.ai) ([SynSense Xylo chip](https://www.synsense.ai/products/xylo/)) | ✓ | ✓ | [Rockpool/Xylo examples](https://neuroir.org/docs/examples/rockpool/nir-conversion/)
+| [Sinabs](https://sinabs.readthedocs.io) ([SynSense Speck chip](https://www.synsense.ai/products/speck-2/)) | ✓ | ✓ | [Sinabs/Speck examples](https://neuroir.org/docs/examples/sinabs/nir-conversion/) |
+| [snnTorch](https://github.com/jeshraghian/snntorch/) | ✓ | ✓ | [snnTorch examples](https://neuroir.org/docs/examples/snntorch/nir-conversion/) |
+| [SpiNNaker2](https://spinncloud.com/portfolio/spinnaker2/) | ⬚ | ✓ | [SpiNNaker2 examples](https://neuroir.org/docs/examples/spinnaker2/import/) |
+| [Spyx](https://github.com/kmheckel/spyx) | ✓ | ✓ | [Spyx examples](https://neuroir.org/docs/examples/spyx/conversion/)
 
 ## Why are some platforms only reading or writing but not both?
 Some platforms support both reading and writing, but in other cases it does not make sense to both read *and* write NIR graphs.

--- a/docs/source/supported_primitives.md
+++ b/docs/source/supported_primitives.md
@@ -3,6 +3,7 @@ This document lists which primitives are supported by the software frameworks fo
 - `→`: Supported for conversion from NIR
 - `←`: Supported for conversion to NIR
 - `⟷`: Supported for both conversion directions (to and from NIR)
+
 Please note that this list is generated automatically and may not be entirely accurate.
 <br />
 


### PR DESCRIPTION
This PR:

- makes jupyter book generate a folder structure (as it was before),
- corrects links in the ReadMe (instead of `docs/page.html` it is now `docs/page/`) and
- links the `favicon.png` in the `myst.yml` that it is used in the documentation too.