### PR TITLE
chore: Syntactic sugar for NIRData

### DIFF
--- a/nir/data_ir/graph.py
+++ b/nir/data_ir/graph.py
@@ -30,6 +30,12 @@ class TimeGriddedData:
                 "and of type np.ndarray"
             )
 
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+    def __setitem__(self, idx, val):
+        self.data[idx] = val
+
     @property
     def shape(self):
         return self.data.shape
@@ -215,6 +221,12 @@ class NIRNodeData:
                 "observables must be a dictionary of EventData or TimeGriddedData"
             )
 
+    def __getitem__(self, idx):
+        return self.observables[idx]
+
+    def __setitem__(self, idx, val):
+        self.observables[idx] = val
+
     def check_observables(self, node: NIRNode):
         """
         Check that the shapes of the observables match the node's output shapes
@@ -242,6 +254,12 @@ class NIRGraphData:
     def __post_init__(self):
         if not isinstance(self.nodes, dict):
             raise TypeError("nodes must be a dictionary of NIRNodeData or NIRGraphData")
+
+    def __getitem__(self, idx):
+        return self.nodes[idx]
+
+    def __setitem__(self, idx, val):
+        self.nodes[idx] = val
 
     def check_nodes(self, graph: NIRGraph):
         """

--- a/tests/test_data_ir.py
+++ b/tests/test_data_ir.py
@@ -142,3 +142,6 @@ def test_setter_getter():
     node_data = nir.NIRNodeData({"spikes": time_gridded_data})
     graph_data = nir.NIRGraphData({"node": node_data})
     assert np.allclose(graph_data["node"]["spikes"][:], spikes)
+    new_spikes = np.random.randint(0, 2, size=(10, 10, 10)).astype(bool)
+    graph_data["node"]["spikes"] = nir.TimeGriddedData(new_spikes, dt)
+    assert np.array_equal(graph_data["node"]["spikes"][:], new_spikes)

--- a/tests/test_data_ir.py
+++ b/tests/test_data_ir.py
@@ -133,3 +133,12 @@ def test_check_nodes():
         }
     )
     graph_data.check_nodes(graph)
+
+
+def test_setter_getter():
+    spikes = np.random.randint(0, 2, size=(10, 10, 10)).astype(bool)
+    dt = 0.1
+    time_gridded_data = nir.TimeGriddedData(spikes, dt)
+    node_data = nir.NIRNodeData({"spikes": time_gridded_data})
+    graph_data = nir.NIRGraphData({"node": node_data})
+    assert np.allclose(graph_data["node"]["spikes"][:], spikes)


### PR DESCRIPTION
With this PR I want to introduce some syntactic sugar to simplify the access of die different observables and nodes in the `NIRGraphData`. Concretely this means that something like
`spikes = nir_graph_data.nodes['lif'].observables['spikes']`
can now be written as
`spikes = nir_graph_data['lif']['spikes']`

What do you think?